### PR TITLE
Fix postgres crash due to array indexing issue

### DIFF
--- a/pgoutput/output_proto.c
+++ b/pgoutput/output_proto.c
@@ -70,6 +70,7 @@ static void tuple_to_proto(
 {
   int	natt;
   int cp = 0;
+  int colnum = 0;
 
   for (natt = 0; natt < tupdesc->natts; natt++)
 	{
@@ -87,7 +88,7 @@ static void tuple_to_proto(
 
     col = (Common__ColumnPb*)palloc(sizeof(Common__ColumnPb));
     common__column_pb__init(col);
-    cols[natt] = col;
+    cols[colnum++] = col;
 
     typ =  attr->atttypid;
     col->name = NameStr(attr->attname);
@@ -211,5 +212,4 @@ void transicatorOutputChangeProto(
 
   OutputPluginPrepareWrite(ctx, true);
   appendBinaryStringInfo(ctx->out, (char*)pack, packSize);
-  OutputPluginWrite(ctx, true);
 }

--- a/pgoutput/output_string.c
+++ b/pgoutput/output_string.c
@@ -195,5 +195,4 @@ void transicatorOutputChangeString(
   }
 
   appendStringInfoChar(ctx->out, '}');
-  OutputPluginWrite(ctx, true);
 }

--- a/pgoutput/output_string.c
+++ b/pgoutput/output_string.c
@@ -134,7 +134,6 @@ void transicatorOutputChangeString(
   class_form = RelationGetForm(relation);
   tupdesc = RelationGetDescr(relation);
 
-  OutputPluginPrepareWrite(ctx, true);
   appendStringInfoChar(ctx->out, '{');
 
   /* TODO will this produce double-quoted table names? */

--- a/pgoutput/transicator_output.c
+++ b/pgoutput/transicator_output.c
@@ -116,6 +116,7 @@ static void outputChange(
   /* Switch back to original context and release everything we "palloc"ed */
   MemoryContextSwitchTo(oldMemCtx);
   MemoryContextReset(state->memCtx);
+  OutputPluginWrite(ctx, true);
 }
 
 void _PG_output_plugin_init(OutputPluginCallbacks *cb) {

--- a/pgoutput/transicator_output.c
+++ b/pgoutput/transicator_output.c
@@ -107,6 +107,7 @@ static void outputChange(
 
   /* Switch to our private memory context so that we will not leak. */
   oldMemCtx = MemoryContextSwitchTo(state->memCtx);
+  OutputPluginPrepareWrite(ctx, true);
   if (state->isBinary) {
     transicatorOutputChangeProto(ctx, txn, relation, change, state);
   } else {


### PR DESCRIPTION
This fixes #17 

The problem was the natt iteration variable was being used as an array index, but it can skip outside the bounds of the array, which was ultimately causing a crash inside the protobuf assertion mechanisms that were detecting the memory error.

I've also moved the write outside the release of the memory context, which makes the output plugin consistent with all the other output plugins I can find, though I don't know if ultimately it matters.