### PR TITLE
Feature/viper config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 bin/
 .idea/
 changeserver/changeserver
+changeserver/data/
 .vscode
 test-reports/
 docker-test-reports/

--- a/changeserver/config.go
+++ b/changeserver/config.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+func SetConfigDefaults() {
+
+	// These defaults are already set in main.go for the 'flag' packages
+	// However, we will set them again here to retain them if/when the
+	// old CLI flags are removed.
+	viper.SetDefault("port", -1)
+	viper.SetDefault("securePort", -1)
+	viper.SetDefault("mgmtPort", -1)
+
+	viper.SetDefault("dbDir", "")
+	viper.SetDefault("pgURL", "")
+	viper.SetDefault("pgSlot", "")
+	viper.SetDefault("maxAgeParam", "")
+	viper.SetDefault("cert", "")
+	viper.SetDefault("key", "")
+	viper.SetDefault("prefix", "")
+
+	viper.SetDefault("degub", false)
+	viper.SetDefault("help", false)
+}
+
+func GetConfig(goflags *flag.FlagSet) error {
+
+	// Set some, hopefully sane, defaults
+	SetConfigDefaults()
+
+	// Parse legacy GO Flags in to pflags ready for Viper
+	pflag.CommandLine.AddGoFlagSet(goflags)
+	pflag.Parse()
+
+	// Bind legacy GO Flags to viper to maintain backwards compatibility
+	viper.BindPFlag("port", pflag.Lookup("p"))
+	viper.BindPFlag("securePort", pflag.Lookup("sp"))
+	viper.BindPFlag("mgmtPort", pflag.Lookup("mp"))
+
+	viper.BindPFlag("dbDir", pflag.Lookup("d"))
+	viper.BindPFlag("pgURL", pflag.Lookup("u"))
+	viper.BindPFlag("pgSlot", pflag.Lookup("s"))
+	viper.BindPFlag("maxAgeParam", pflag.Lookup("m"))
+	viper.BindPFlag("cert", pflag.Lookup("cert"))
+	viper.BindPFlag("key", pflag.Lookup("key"))
+	viper.BindPFlag("prefix", pflag.Lookup("P"))
+
+	viper.BindPFlag("configFile", pflag.Lookup("C"))
+	viper.BindPFlag("debug", pflag.Lookup("D"))
+	viper.BindPFlag("help", pflag.Lookup("h"))
+
+	// Load config values from file
+	if viper.GetBool("configFile") {
+		viper.SetConfigName(appName)                                               // name of config file (without extension)
+		viper.AddConfigPath(fmt.Sprintf("/etc/%s/", packageName))                  // path to look for the config file in
+		viper.AddConfigPath(fmt.Sprintf("%s/.%s", os.Getenv("HOME"), packageName)) // loof for config in the users home directory
+		viper.AddConfigPath(".")                                                   // look for config in the working directory
+		err := viper.ReadInConfig()                                                // Find and read the config file
+		if err != nil {                                                            // Handle errors reading the config file
+			return err
+		}
+	}
+
+	return nil
+
+}

--- a/changeserver/config.go
+++ b/changeserver/config.go
@@ -70,7 +70,21 @@ func GetConfig(goflags *flag.FlagSet) error {
 
 	// Load any config values from Environment variables who's name is prefixed TCS_ (Transicator Change Server)
 	viper.SetEnvPrefix("tcs") // will be uppercased automatically
+
 	viper.BindEnv("port")
+	viper.BindEnv("securePort")
+	viper.BindEnv("mgmtPort")
+
+	viper.BindEnv("dbDir")
+	viper.BindEnv("pgURL")
+	viper.BindEnv("pgSlot")
+	viper.BindEnv("maxAgeParam")
+	viper.BindEnv("cert")
+	viper.BindEnv("key")
+	viper.BindEnv("prefix")
+
+	viper.BindEnv("degub")
+	viper.BindEnv("help")
 
 	return nil
 

--- a/changeserver/config.go
+++ b/changeserver/config.go
@@ -68,6 +68,10 @@ func GetConfig(goflags *flag.FlagSet) error {
 		}
 	}
 
+	// Load any config values from Environment variables who's name is prefixed TCS_ (Transicator Change Server)
+	viper.SetEnvPrefix("tcs") // will be uppercased automatically
+	viper.BindEnv("port")
+
 	return nil
 
 }

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,6 +10,8 @@ import:
   - proto
 - package: github.com/30x/goscaffold
   version: master
+- package: github.com/spf13/viper
+  version: master
 testImport:
 - package: github.com/onsi/ginkgo
 - package: github.com/onsi/gomega

--- a/glide.yaml
+++ b/glide.yaml
@@ -12,6 +12,8 @@ import:
   version: master
 - package: github.com/spf13/viper
   version: master
+- package: github.com/spf13/pflag
+  version: master
 testImport:
 - package: github.com/onsi/ginkgo
 - package: github.com/onsi/gomega

--- a/snapshotserver/config.go
+++ b/snapshotserver/config.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+func SetConfigDefaults() {
+
+	// These defaults are already set in main.go for the 'flag' packages
+	// However, we will set them again here to retain them if/when the
+	// old CLI flags are removed.
+	viper.SetDefault("port", -1)
+	viper.SetDefault("securePort", -1)
+	viper.SetDefault("mgmtPort", -1)
+
+	viper.SetDefault("pgURL", "")
+	viper.SetDefault("key", "")
+	viper.SetDefault("cert", "")
+
+	viper.SetDefault("degub", false)
+	viper.SetDefault("help", false)
+}
+
+func GetConfig(goflags *flag.FlagSet) error {
+
+	// Set some, hopefully sane, defaults
+	SetConfigDefaults()
+
+	// Parse legacy GO Flags in to pflags ready for Viper
+	pflag.CommandLine.AddGoFlagSet(goflags)
+	pflag.Parse()
+
+	// Bind legacy GO Flags to viper to maintain backwards compatibility
+	viper.BindPFlag("port", pflag.Lookup("p"))
+	viper.BindPFlag("securePort", pflag.Lookup("sp"))
+	viper.BindPFlag("mgmtPort", pflag.Lookup("mp"))
+
+	viper.BindPFlag("pgURL", pflag.Lookup("u"))
+	viper.BindPFlag("key", pflag.Lookup("key"))
+	viper.BindPFlag("cert", pflag.Lookup("cert"))
+
+	viper.BindPFlag("configFile", pflag.Lookup("C"))
+	viper.BindPFlag("debug", pflag.Lookup("D"))
+	viper.BindPFlag("help", pflag.Lookup("h"))
+
+	// Load config values from file
+	if viper.GetBool("configFile") {
+		viper.SetConfigName(appName)                                               // name of config file (without extension)
+		viper.AddConfigPath(fmt.Sprintf("/etc/%s/", packageName))                  // path to look for the config file in
+		viper.AddConfigPath(fmt.Sprintf("%s/.%s", os.Getenv("HOME"), packageName)) // loof for config in the users home directory
+		viper.AddConfigPath(".")                                                   // look for config in the working directory
+		err := viper.ReadInConfig()                                                // Find and read the config file
+		if err != nil {                                                            // Handle errors reading the config file
+			return err
+		}
+	}
+
+	// Load any config values from Environment variables who's name is prefixed TSS_ (Transicator Snaphot Server)
+	viper.SetEnvPrefix("tss") // will be uppercased automatically
+
+	viper.BindEnv("port")
+	viper.BindEnv("securePort")
+	viper.BindEnv("mgmtPort")
+
+	viper.BindEnv("pgURL")
+	viper.BindEnv("key")
+	viper.BindEnv("cert")
+
+	viper.BindEnv("configFile")
+	viper.BindEnv("debug")
+	viper.BindEnv("help")
+
+	return nil
+
+}


### PR DESCRIPTION
This PR relates to: https://github.com/apigee-labs/transicator/issues/19

Adds support for `spf13/viper` while maintaining backwards compatibility with the existing `flags` options.

#### Examples
```
$ ./changeserver
port => -1

$ ./changeserver -p 1234
port => 1234 
```
You can now create either a `.json`, `.yaml`, `.toml` etc file (anything supported by Viper) called `changeserver` in either `/etc/transicator`, `~/.transicator` or `./`
```
$ vi /etc/transicator/changeserver.json
{
  "port": 11223
}
$ ./changeserver -C
port => 11223
```
Or set an Environment Variable prefixed with `TCS_` to override all of the above
```
$ TCS_PORT=33221 ./changeserver -p 1234
port => 33221
```