### PR TITLE
Dont double destroy the dbOpts structure

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -105,7 +105,6 @@ func OpenDB(baseFile string) (*DB, error) {
 	var err error
 
 	dbOpts := gorocksdb.NewDefaultOptions()
-	defer dbOpts.Destroy()
 	dbOpts.SetCreateIfMissing(true)
 	dbOpts.SetCreateIfMissingColumnFamilies(true)
 	stor.dbOpts = dbOpts


### PR DESCRIPTION
This one is insidious: If you defer the destroy here, you don't match the lifecycle of the database and then you trigger random segfaults later. This structure is correctly destroyed at line 150.

