### PR TITLE
Renamed _apid_scope to more generic name _change_selector. All REST A…

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Now, start a snapshot server running on port 9001:
 
 You can test quickly -- this API call should return "303 See Other":
 
-    curl -v http://localhost:9001/snapshots?change_selector=foo
+    curl -v http://localhost:9001/snapshots?scope=foo
 
 Finally, start a change server running on port 9000:
 
@@ -146,7 +146,7 @@ INSERT 0 1
 We can now get a snapshot in JSON format using the snapshot server:
 
 ````
-$ curl -H "Accept: application/json" -L http://localhost:9001/snapshots?change_selector=foo
+$ curl -H "Accept: application/json" -L http://localhost:9001/snapshots?scope=foo
 
 {"snapshotInfo":"229444:229444:","timestamp":"2016-10-13T17:42:12.171306-07:00",
 "tables":[{"name":"public.snapshot_test","rows":[]},{"name":"scope","rows":[
@@ -175,7 +175,7 @@ Postgres transactions were visible when the snapshot was created.
 At this point, using the changeserver, a client may issue the following
 API call:
 
-    curl -H "Accept: application/json" "http://localhost:9000/changes?snapshot=229444:229444:&change_selector=foo&block=10"
+    curl -H "Accept: application/json" "http://localhost:9000/changes?snapshot=229444:229444:&scope=foo&block=10"
 
 This call asks for all the changes for the scope "foo" starting from the first
 change that was not visible in the sequence. If no changes appear for 10 seconds,
@@ -195,14 +195,14 @@ Once the first set of changes has been retrieved, the "lastSequence" parameter
 tells us where in the change stream we left off. We can now use this
 in another API call to wait for more changes:
 
-    curl -H "Accept: application/json" "http://changeserver/changes?since=0.1390d838.0&change_selector=foo&block=10"
+    curl -H "Accept: application/json" "http://changeserver/changes?since=0.1390d838.0&scope=foo&block=10"
 
 This call won't result in any changes either but it will return us another sequence
 if anything changed in the database.
 
 Let's try again (with a longer timeout this time):
 
-    curl -H "Accept: application/json" "http://changeserver/changes?since=0.1390d838.0&change_selector=foo&block=60"
+    curl -H "Accept: application/json" "http://changeserver/changes?since=0.1390d838.0&scope=foo&block=60"
 
 and while we're waiting, let's use another window to insert something to the database:
 
@@ -254,7 +254,7 @@ when the transactions commit. Rolled back transactions will never appear.
 
 For instance:
 
-    curl -H "Accept: application/json" "http://localhost:9000/changes?change_selector=foo&bock=60&since=0.1392ed18.0"
+    curl -H "Accept: application/json" "http://localhost:9000/changes?scope=foo&bock=60&since=0.1392ed18.0"
 
 and then...
 

--- a/changeserver/changes_api_test.go
+++ b/changeserver/changes_api_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Changes API Tests", func() {
 
 	It("Empty database", func() {
 		bod := executeGet(fmt.Sprintf(
-			"%s/changes?change_selector=foo", baseURL))
+			"%s/changes?scope=foo", baseURL))
 		cl, err := common.UnmarshalChangeList(bod)
 		Expect(err).Should(Succeed())
 		Expect(cl.Changes).Should(BeEmpty())
@@ -51,7 +51,7 @@ var _ = Describe("Changes API Tests", func() {
 
 		Eventually(func() bool {
 			bod := executeGet(fmt.Sprintf(
-				"%s/changes?since=%s&change_selector=boop", baseURL, lastChangeSequence))
+				"%s/changes?since=%s&scope=boop", baseURL, lastChangeSequence))
 			cl, err := common.UnmarshalChangeList(bod)
 			Expect(err).Should(Succeed())
 			if len(cl.Changes) == 0 {
@@ -80,7 +80,7 @@ var _ = Describe("Changes API Tests", func() {
 
 		Eventually(func() bool {
 			bod := executeGet(fmt.Sprintf(
-				"%s/changes?since=%s&change_selector=foo", baseURL, lastChangeSequence))
+				"%s/changes?since=%s&scope=foo", baseURL, lastChangeSequence))
 			cl, err := common.UnmarshalChangeList(bod)
 			Expect(err).Should(Succeed())
 			if len(cl.Changes) == 0 {
@@ -110,7 +110,7 @@ var _ = Describe("Changes API Tests", func() {
 
 		Eventually(func() bool {
 			cl := getChanges(fmt.Sprintf(
-				"%s/changes?since=%s&change_selector=foo", baseURL, lastChangeSequence))
+				"%s/changes?since=%s&scope=foo", baseURL, lastChangeSequence))
 			if len(cl.Changes) < 1 {
 				return false
 			}
@@ -149,7 +149,7 @@ var _ = Describe("Changes API Tests", func() {
 		// Without snapshot ID, should get two changes
 		Eventually(func() bool {
 			cl := getChanges(fmt.Sprintf(
-				"%s/changes?since=%s&change_selector=foo", baseURL, lastChangeSequence))
+				"%s/changes?since=%s&scope=foo", baseURL, lastChangeSequence))
 			if len(cl.Changes) < 2 {
 				return false
 			}
@@ -169,7 +169,7 @@ var _ = Describe("Changes API Tests", func() {
 		Eventually(func() bool {
 			fmt.Fprintf(GinkgoWriter, "Reading with snapshot %s\n", snap)
 			cl := getChanges(fmt.Sprintf(
-				"%s/changes?since=%s&change_selector=foo&snapshot=%s",
+				"%s/changes?since=%s&scope=foo&snapshot=%s",
 				baseURL, lastChangeSequence, snap))
 			if len(cl.Changes) < 1 {
 				return false
@@ -197,7 +197,7 @@ var _ = Describe("Changes API Tests", func() {
 
 		Eventually(func() bool {
 			cl := getChanges(fmt.Sprintf(
-				"%s/changes?since=%s&change_selector=foo", baseURL, origLastSequence))
+				"%s/changes?since=%s&scope=foo", baseURL, origLastSequence))
 			if len(cl.Changes) != 4 {
 				return false
 			}
@@ -210,23 +210,23 @@ var _ = Describe("Changes API Tests", func() {
 
 		// Un-matched scope
 		cl := getChanges(fmt.Sprintf(
-			"%s/changes?since=%s&change_selector=bar", baseURL, origLastSequence))
+			"%s/changes?since=%s&scope=bar", baseURL, origLastSequence))
 		Expect(cl.Changes).Should(BeEmpty())
 
 		// Out of range
 		oorSeq := common.MakeSequence(lastChangeSequence.LSN+10, lastChangeSequence.Index)
 		cl = getChanges(fmt.Sprintf(
-			"%s/changes?since=%s&change_selector=foo", baseURL, oorSeq))
+			"%s/changes?since=%s&scope=foo", baseURL, oorSeq))
 		Expect(cl.Changes).Should(BeEmpty())
 
 		// Short limit
 		cl = getChanges(fmt.Sprintf(
-			"%s/changes?since=%s&change_selector=foo&limit=0", baseURL, origLastSequence))
+			"%s/changes?since=%s&scope=foo&limit=0", baseURL, origLastSequence))
 		Expect(cl.Changes).Should(BeEmpty())
 
 		// Less short limit
 		cl = getChanges(fmt.Sprintf(
-			"%s/changes?since=%s&change_selector=foo&limit=1", baseURL, origLastSequence))
+			"%s/changes?since=%s&scope=foo&limit=1", baseURL, origLastSequence))
 		Expect(len(cl.Changes)).Should(Equal(1))
 		Expect(compareSequence(cl, 0, lastTestSequence-3)).Should(BeTrue())
 	})
@@ -234,14 +234,14 @@ var _ = Describe("Changes API Tests", func() {
 	It("Long polling empty", func() {
 		lastCommit := lastChangeSequence
 		cl := getChanges(fmt.Sprintf(
-			"%s/changes?since=%s&change_selector=foo", baseURL, lastChangeSequence))
+			"%s/changes?since=%s&scope=foo", baseURL, lastChangeSequence))
 		if len(cl.Changes) > 0 {
 			lastCommit = cl.Changes[len(cl.Changes)-1].GetSequence()
 		}
 
 		oorSeq := common.MakeSequence(lastCommit.LSN+10, lastCommit.Index)
 		cl = getChanges(fmt.Sprintf(
-			"%s/changes?since=%s&change_selector=foo&block=1", baseURL, oorSeq))
+			"%s/changes?since=%s&scope=foo&block=1", baseURL, oorSeq))
 		Expect(cl.Changes).Should(BeEmpty())
 	})
 
@@ -250,10 +250,10 @@ var _ = Describe("Changes API Tests", func() {
 
 		go func() {
 			lc := getChanges(fmt.Sprintf(
-				"%s/changes?since=%s&change_selector=foo", baseURL, lastChangeSequence))
+				"%s/changes?since=%s&scope=foo", baseURL, lastChangeSequence))
 			resultChan <- lc
 			lc = getChanges(fmt.Sprintf(
-				"%s/changes?since=%s&change_selector=foo&block=30", baseURL, lastChangeSequence))
+				"%s/changes?since=%s&scope=foo&block=30", baseURL, lastChangeSequence))
 			resultChan <- lc
 		}()
 
@@ -284,10 +284,10 @@ var _ = Describe("Changes API Tests", func() {
 
 		go func() {
 			lc := getChanges(fmt.Sprintf(
-				"%s/changes?snapshot=%s&change_selector=foo", baseURL, snapshot))
+				"%s/changes?snapshot=%s&scope=foo", baseURL, snapshot))
 			resultChan <- lc
 			lc = getChanges(fmt.Sprintf(
-				"%s/changes?snapshot=%s&change_selector=foo&block=30", baseURL, snapshot))
+				"%s/changes?snapshot=%s&scope=foo&block=30", baseURL, snapshot))
 			resultChan <- lc
 		}()
 
@@ -337,10 +337,10 @@ var _ = Describe("Changes API Tests", func() {
 
 		go func() {
 			lc := getChanges(fmt.Sprintf(
-				"%s/changes?since=%s&change_selector=foo&change_selector=bar", baseURL, lastChangeSequence))
+				"%s/changes?since=%s&scope=foo&scope=bar", baseURL, lastChangeSequence))
 			resultChan <- lc
 			lc = getChanges(fmt.Sprintf(
-				"%s/changes?since=%s&change_selector=foo&change_selector=bar&block=30", baseURL, lastChangeSequence))
+				"%s/changes?since=%s&scope=foo&scope=bar&block=30", baseURL, lastChangeSequence))
 			resultChan <- lc
 		}()
 
@@ -375,7 +375,7 @@ var _ = Describe("Changes API Tests", func() {
 		// Should still be there for five seconds...
 		Eventually(func() int {
 			lc := getChanges(fmt.Sprintf(
-				"%s/changes?change_selector=clean", baseURL))
+				"%s/changes?scope=clean", baseURL))
 			if len(lc.Changes) > 0 {
 				Expect(compareSequence(lc, 0, lastTestSequence)).Should(BeTrue())
 				newLast = lc.Changes[0].GetSequence()
@@ -390,7 +390,7 @@ var _ = Describe("Changes API Tests", func() {
 		// And should be cleaned up within 10
 		Eventually(func() int {
 			lcc := getChanges(fmt.Sprintf(
-				"%s/changes?change_selector=clean", baseURL))
+				"%s/changes?scope=clean", baseURL))
 			return len(lcc.Changes)
 		}, 10*time.Second, time.Second).Should(BeZero())
 	})

--- a/changeserver/changes_api_test.go
+++ b/changeserver/changes_api_test.go
@@ -35,23 +35,23 @@ var _ = Describe("Changes API Tests", func() {
 
 	It("Empty database", func() {
 		bod := executeGet(fmt.Sprintf(
-			"%s/changes?scope=foo", baseURL))
+			"%s/changes?change_selector=foo", baseURL))
 		cl, err := common.UnmarshalChangeList(bod)
 		Expect(err).Should(Succeed())
 		Expect(cl.Changes).Should(BeEmpty())
 	})
 
-	It("Different scope", func() {
-		scopeField = "_different_scope"
-		defer func() { scopeField = "_apid_scope" }()
+	It("Different selector", func() {
+		selectorColumn = "_different_selector"
+		defer func() { selectorColumn = "_change_selector" }()
 		lastTestSequence++
-		fmt.Fprintf(GinkgoWriter, "Insert alternative scope sequence %d\n", lastTestSequence)
-		_, err := insertAlterativeScopeStmt.Exec(lastTestSequence, "boop")
+		fmt.Fprintf(GinkgoWriter, "Insert alternative selector sequence %d\n", lastTestSequence)
+		_, err := insertAlterativeSelectorStmt.Exec(lastTestSequence, "boop")
 		Expect(err).Should(Succeed())
 
 		Eventually(func() bool {
 			bod := executeGet(fmt.Sprintf(
-				"%s/changes?since=%s&scope=boop", baseURL, lastChangeSequence))
+				"%s/changes?since=%s&change_selector=boop", baseURL, lastChangeSequence))
 			cl, err := common.UnmarshalChangeList(bod)
 			Expect(err).Should(Succeed())
 			if len(cl.Changes) == 0 {
@@ -80,7 +80,7 @@ var _ = Describe("Changes API Tests", func() {
 
 		Eventually(func() bool {
 			bod := executeGet(fmt.Sprintf(
-				"%s/changes?since=%s&scope=foo", baseURL, lastChangeSequence))
+				"%s/changes?since=%s&change_selector=foo", baseURL, lastChangeSequence))
 			cl, err := common.UnmarshalChangeList(bod)
 			Expect(err).Should(Succeed())
 			if len(cl.Changes) == 0 {
@@ -110,7 +110,7 @@ var _ = Describe("Changes API Tests", func() {
 
 		Eventually(func() bool {
 			cl := getChanges(fmt.Sprintf(
-				"%s/changes?since=%s&scope=foo", baseURL, lastChangeSequence))
+				"%s/changes?since=%s&change_selector=foo", baseURL, lastChangeSequence))
 			if len(cl.Changes) < 1 {
 				return false
 			}
@@ -149,7 +149,7 @@ var _ = Describe("Changes API Tests", func() {
 		// Without snapshot ID, should get two changes
 		Eventually(func() bool {
 			cl := getChanges(fmt.Sprintf(
-				"%s/changes?since=%s&scope=foo", baseURL, lastChangeSequence))
+				"%s/changes?since=%s&change_selector=foo", baseURL, lastChangeSequence))
 			if len(cl.Changes) < 2 {
 				return false
 			}
@@ -169,7 +169,7 @@ var _ = Describe("Changes API Tests", func() {
 		Eventually(func() bool {
 			fmt.Fprintf(GinkgoWriter, "Reading with snapshot %s\n", snap)
 			cl := getChanges(fmt.Sprintf(
-				"%s/changes?since=%s&scope=foo&snapshot=%s",
+				"%s/changes?since=%s&change_selector=foo&snapshot=%s",
 				baseURL, lastChangeSequence, snap))
 			if len(cl.Changes) < 1 {
 				return false
@@ -197,7 +197,7 @@ var _ = Describe("Changes API Tests", func() {
 
 		Eventually(func() bool {
 			cl := getChanges(fmt.Sprintf(
-				"%s/changes?since=%s&scope=foo", baseURL, origLastSequence))
+				"%s/changes?since=%s&change_selector=foo", baseURL, origLastSequence))
 			if len(cl.Changes) != 4 {
 				return false
 			}
@@ -210,23 +210,23 @@ var _ = Describe("Changes API Tests", func() {
 
 		// Un-matched scope
 		cl := getChanges(fmt.Sprintf(
-			"%s/changes?since=%s&scope=bar", baseURL, origLastSequence))
+			"%s/changes?since=%s&change_selector=bar", baseURL, origLastSequence))
 		Expect(cl.Changes).Should(BeEmpty())
 
 		// Out of range
 		oorSeq := common.MakeSequence(lastChangeSequence.LSN+10, lastChangeSequence.Index)
 		cl = getChanges(fmt.Sprintf(
-			"%s/changes?since=%s&scope=foo", baseURL, oorSeq))
+			"%s/changes?since=%s&change_selector=foo", baseURL, oorSeq))
 		Expect(cl.Changes).Should(BeEmpty())
 
 		// Short limit
 		cl = getChanges(fmt.Sprintf(
-			"%s/changes?since=%s&scope=foo&limit=0", baseURL, origLastSequence))
+			"%s/changes?since=%s&change_selector=foo&limit=0", baseURL, origLastSequence))
 		Expect(cl.Changes).Should(BeEmpty())
 
 		// Less short limit
 		cl = getChanges(fmt.Sprintf(
-			"%s/changes?since=%s&scope=foo&limit=1", baseURL, origLastSequence))
+			"%s/changes?since=%s&change_selector=foo&limit=1", baseURL, origLastSequence))
 		Expect(len(cl.Changes)).Should(Equal(1))
 		Expect(compareSequence(cl, 0, lastTestSequence-3)).Should(BeTrue())
 	})
@@ -234,14 +234,14 @@ var _ = Describe("Changes API Tests", func() {
 	It("Long polling empty", func() {
 		lastCommit := lastChangeSequence
 		cl := getChanges(fmt.Sprintf(
-			"%s/changes?since=%s&scope=foo", baseURL, lastChangeSequence))
+			"%s/changes?since=%s&change_selector=foo", baseURL, lastChangeSequence))
 		if len(cl.Changes) > 0 {
 			lastCommit = cl.Changes[len(cl.Changes)-1].GetSequence()
 		}
 
 		oorSeq := common.MakeSequence(lastCommit.LSN+10, lastCommit.Index)
 		cl = getChanges(fmt.Sprintf(
-			"%s/changes?since=%s&scope=foo&block=1", baseURL, oorSeq))
+			"%s/changes?since=%s&change_selector=foo&block=1", baseURL, oorSeq))
 		Expect(cl.Changes).Should(BeEmpty())
 	})
 
@@ -250,10 +250,10 @@ var _ = Describe("Changes API Tests", func() {
 
 		go func() {
 			lc := getChanges(fmt.Sprintf(
-				"%s/changes?since=%s&scope=foo", baseURL, lastChangeSequence))
+				"%s/changes?since=%s&change_selector=foo", baseURL, lastChangeSequence))
 			resultChan <- lc
 			lc = getChanges(fmt.Sprintf(
-				"%s/changes?since=%s&scope=foo&block=30", baseURL, lastChangeSequence))
+				"%s/changes?since=%s&change_selector=foo&block=30", baseURL, lastChangeSequence))
 			resultChan <- lc
 		}()
 
@@ -284,10 +284,10 @@ var _ = Describe("Changes API Tests", func() {
 
 		go func() {
 			lc := getChanges(fmt.Sprintf(
-				"%s/changes?snapshot=%s&scope=foo", baseURL, snapshot))
+				"%s/changes?snapshot=%s&change_selector=foo", baseURL, snapshot))
 			resultChan <- lc
 			lc = getChanges(fmt.Sprintf(
-				"%s/changes?snapshot=%s&scope=foo&block=30", baseURL, snapshot))
+				"%s/changes?snapshot=%s&change_selector=foo&block=30", baseURL, snapshot))
 			resultChan <- lc
 		}()
 
@@ -307,7 +307,7 @@ var _ = Describe("Changes API Tests", func() {
 		lastChangeSequence = cl.Changes[0].GetSequence()
 	})
 
-	It("Long polling no scope", func() {
+	It("Long polling no selector", func() {
 		resultChan := make(chan *common.ChangeList, 1)
 
 		go func() {
@@ -332,15 +332,15 @@ var _ = Describe("Changes API Tests", func() {
 		lastChangeSequence = cl.Changes[0].GetSequence()
 	})
 
-	It("Long polling two scopes", func() {
+	It("Long polling two selectors", func() {
 		resultChan := make(chan *common.ChangeList, 1)
 
 		go func() {
 			lc := getChanges(fmt.Sprintf(
-				"%s/changes?since=%s&scope=foo&scope=bar", baseURL, lastChangeSequence))
+				"%s/changes?since=%s&change_selector=foo&change_selector=bar", baseURL, lastChangeSequence))
 			resultChan <- lc
 			lc = getChanges(fmt.Sprintf(
-				"%s/changes?since=%s&scope=foo&scope=bar&block=30", baseURL, lastChangeSequence))
+				"%s/changes?since=%s&change_selector=foo&change_selector=bar&block=30", baseURL, lastChangeSequence))
 			resultChan <- lc
 		}()
 
@@ -375,7 +375,7 @@ var _ = Describe("Changes API Tests", func() {
 		// Should still be there for five seconds...
 		Eventually(func() int {
 			lc := getChanges(fmt.Sprintf(
-				"%s/changes?scope=clean", baseURL))
+				"%s/changes?change_selector=clean", baseURL))
 			if len(lc.Changes) > 0 {
 				Expect(compareSequence(lc, 0, lastTestSequence)).Should(BeTrue())
 				newLast = lc.Changes[0].GetSequence()
@@ -390,7 +390,7 @@ var _ = Describe("Changes API Tests", func() {
 		// And should be cleaned up within 10
 		Eventually(func() int {
 			lcc := getChanges(fmt.Sprintf(
-				"%s/changes?scope=clean", baseURL))
+				"%s/changes?change_selector=clean", baseURL))
 			return len(lcc.Changes)
 		}, 10*time.Second, time.Second).Should(BeZero())
 	})

--- a/changeserver/changesapi.go
+++ b/changeserver/changesapi.go
@@ -56,7 +56,7 @@ func (s *server) handleGetChanges(resp http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	selectors := q["change_selector"]
+	selectors := q["scope"]
 	if len(selectors) == 0 {
 		selectors = []string{""}
 	}

--- a/changeserver/changetracker.go
+++ b/changeserver/changetracker.go
@@ -33,14 +33,14 @@ type trackerUpdate struct {
 	updateType int
 	key        int32
 	change     common.Sequence
-	scope      string
+	selector   string
 	waiter     changeWaiter
 }
 
 type changeWaiter struct {
-	change common.Sequence
-	scopes map[string]bool
-	rc     chan common.Sequence
+	change    common.Sequence
+	selectors map[string]bool
+	rc        chan common.Sequence
 }
 
 /*
@@ -81,11 +81,11 @@ func (t *changeTracker) close() {
 Update indicates that the current sequence has changed. Wake up any waiting
 waiters and tell them about it.
 */
-func (t *changeTracker) update(change common.Sequence, scope string) {
+func (t *changeTracker) update(change common.Sequence, selector string) {
 	u := trackerUpdate{
 		updateType: update,
 		change:     change,
-		scope:      scope,
+		selector:      selector,
 	}
 	t.updateChan <- u
 }
@@ -94,8 +94,8 @@ func (t *changeTracker) update(change common.Sequence, scope string) {
 Wait blocks the calling gorouting forever until the change tracker has reached a value at least as high as
 "curChange." Return the current value when that happens.
 */
-func (t *changeTracker) wait(curChange common.Sequence, scopes []string) common.Sequence {
-	_, resultChan := t.doWait(curChange, scopes)
+func (t *changeTracker) wait(curChange common.Sequence, selectors []string) common.Sequence {
+	_, resultChan := t.doWait(curChange, selectors)
 	return <-resultChan
 }
 
@@ -104,8 +104,8 @@ TimedWait blocks the current gorouting until either a new value higher than
 "curChange" has been reached, or "maxWait" has been exceeded.
 */
 func (t *changeTracker) timedWait(
-	curChange common.Sequence, maxWait time.Duration, scopes []string) common.Sequence {
-	key, resultChan := t.doWait(curChange, scopes)
+	curChange common.Sequence, maxWait time.Duration, selectors []string) common.Sequence {
+	key, resultChan := t.doWait(curChange, selectors)
 	timer := time.NewTimer(maxWait)
 	select {
 	case result := <-resultChan:
@@ -120,12 +120,12 @@ func (t *changeTracker) timedWait(
 	}
 }
 
-func (t *changeTracker) doWait(curChange common.Sequence, scopes []string) (int32, chan common.Sequence) {
+func (t *changeTracker) doWait(curChange common.Sequence, selectors []string) (int32, chan common.Sequence) {
 	key := atomic.AddInt32(&t.lastKey, 1)
 	resultChan := make(chan common.Sequence, 1)
-	scopeMap := make(map[string]bool)
-	for _, s := range scopes {
-		scopeMap[s] = true
+	selectorMap := make(map[string]bool)
+	for _, s := range selectors {
+		selectorMap[s] = true
 	}
 
 	u := trackerUpdate{
@@ -133,7 +133,7 @@ func (t *changeTracker) doWait(curChange common.Sequence, scopes []string) (int3
 		key:        key,
 		waiter: changeWaiter{
 			change: curChange,
-			scopes: scopeMap,
+			selectors: selectorMap,
 			rc:     resultChan,
 		},
 	}
@@ -166,18 +166,18 @@ func (t *changeTracker) run() {
 
 	// Close out all waiting waiters
 	for _, w := range t.waiters {
-		w.rc <- t.getMaxChange(w.scopes)
+		w.rc <- t.getMaxChange(w.selectors)
 	}
 }
 
 func (t *changeTracker) handleUpdate(up trackerUpdate) {
 	// Changes might come out of order
-	if up.change.Compare(t.lastChanges[up.scope]) > 0 {
-		t.lastChanges[up.scope] = up.change
+	if up.change.Compare(t.lastChanges[up.selector]) > 0 {
+		t.lastChanges[up.selector] = up.change
 	}
 
 	for k, w := range t.waiters {
-		if up.change.Compare(w.change) >= 0 && w.scopes[up.scope] {
+		if up.change.Compare(w.change) >= 0 && w.selectors[up.selector] {
 			//log.Debugf("Waking up waiter waiting for change %d with change %d and tag %s",
 			//	w.change, up.change, up.tag)
 			w.rc <- up.change
@@ -187,7 +187,7 @@ func (t *changeTracker) handleUpdate(up trackerUpdate) {
 }
 
 func (t *changeTracker) handleWaiter(u trackerUpdate) {
-	maxAlready := t.getMaxChange(u.waiter.scopes)
+	maxAlready := t.getMaxChange(u.waiter.selectors)
 	if maxAlready.Compare(u.waiter.change) >= 0 {
 		u.waiter.rc <- maxAlready
 	} else {
@@ -199,11 +199,11 @@ func (t *changeTracker) handleCancel(key int32) {
 	delete(t.waiters, key)
 }
 
-func (t *changeTracker) getMaxChange(scopes map[string]bool) common.Sequence {
+func (t *changeTracker) getMaxChange(selectors map[string]bool) common.Sequence {
 	var max common.Sequence
-	for scope := range scopes {
-		if t.lastChanges[scope].Compare(max) > 0 {
-			max = t.lastChanges[scope]
+	for selector := range selectors {
+		if t.lastChanges[selector].Compare(max) > 0 {
+			max = t.lastChanges[selector]
 		}
 	}
 	return max

--- a/changeserver/changetracker_test.go
+++ b/changeserver/changetracker_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Change tracker", func() {
 		Expect(behind.LSN).Should(BeEquivalentTo(2))
 	})
 
-	It("Behind with scopes", func() {
+	It("Behind with selectors", func() {
 		tracker.update(common.MakeSequence(3, 0), "foo")
 		tracker.update(common.MakeSequence(4, 0), "bar")
 		behind := tracker.wait(common.MakeSequence(1, 0), []string{"foo"})
@@ -68,7 +68,7 @@ var _ = Describe("Change tracker", func() {
 		Expect(behind.LSN).Should(BeEquivalentTo(2))
 	})
 
-	It("Caught up with scopes", func() {
+	It("Caught up with selectors", func() {
 		tracker.update(common.MakeSequence(3, 0), "foo")
 		tracker.update(common.MakeSequence(4, 0), "bar")
 		time.Sleep(time.Millisecond * 250)
@@ -177,7 +177,7 @@ var _ = Describe("Change tracker", func() {
 		Eventually(doneChan).Should(Receive(BeEquivalentTo(4)))
 	})
 
-	It("Update with scopes", func() {
+	It("Update with selectors", func() {
 		doneChan := make(chan uint64, 1)
 
 		go func() {
@@ -192,7 +192,7 @@ var _ = Describe("Change tracker", func() {
 		Eventually(doneChan).Should(Receive(BeEquivalentTo(4)))
 	})
 
-	It("Update with two scopes", func() {
+	It("Update with two selectors", func() {
 		doneChan := make(chan uint64, 1)
 
 		go func() {

--- a/changeserver/config.go
+++ b/changeserver/config.go
@@ -45,9 +45,9 @@ func setConfigDefaults() {
 	pflag.String("key", "", "TLS key PEM file (must be unencrypted)")
 	viper.SetDefault("key", "")
 	pflag.StringP("prefix", "P", "", "Optional prefix URL for all API calls")
-	pflag.StringP("scopefield", "S", "", "Set the scopeField database column")
+	pflag.StringP("selectorcolumn", "S", "", "Set the selector column")
 	viper.SetDefault("prefix", "")
-	viper.SetDefault("scopeField", defaultScopeField)
+	viper.SetDefault("selectorColumn", defaultSelectorColumn)
 
 	pflag.BoolP("config", "C", false, fmt.Sprintf("Use a config file named '%s' located in either /etc/%s/, ~/.%s or ./)", appName, packageName, packageName))
 	pflag.BoolP("debug", "D", false, "Turn on debugging")
@@ -70,7 +70,7 @@ func getConfig() error {
 
 	viper.BindPFlag("configFile", pflag.Lookup("config"))
 	viper.BindPFlag("debug", pflag.Lookup("debug"))
-	viper.BindPFlag("scopeField", pflag.Lookup("scopefield"))
+	viper.BindPFlag("selectorColumn", pflag.Lookup("selectorcolumn"))
 
 	// Load config values from file
 	if viper.GetBool("configFile") {

--- a/changeserver/main.go
+++ b/changeserver/main.go
@@ -84,7 +84,7 @@ func runMain() int {
 	cert := viper.GetString("cert")
 	key := viper.GetString("key")
 	prefix := viper.GetString("prefix")
-	scopeFieldParam := viper.GetString("scopeField")
+	selectorColumnParam := viper.GetString("selectorColumn")
 
 	debug := viper.GetBool("debug")
 
@@ -109,7 +109,7 @@ func runMain() int {
 	}
 
 	// Set the global scopeField from server.go to the user supplied value
-	scopeField = scopeFieldParam
+	selectorColumn = selectorColumnParam
 
 	if debug {
 		logrus.SetLevel(logrus.DebugLevel)

--- a/changeserver/replicator.go
+++ b/changeserver/replicator.go
@@ -65,15 +65,15 @@ func (s *server) handleChange(c *common.Change, firstChange common.Sequence) com
 	changeSeq := c.GetSequence()
 
 	if changeSeq.Compare(firstChange) > 0 {
-		scope := getScope(c)
-		log.Debugf("Received change %d for scope %s", c.ChangeSequence, scope)
+		selector := getSelector(c)
+		log.Debugf("Received change %d for selector %s", c.ChangeSequence, selector)
 		if c.Timestamp == 0 {
 			c.Timestamp = time.Now().Unix()
 		}
 		dataBuf := encodeChangeProto(c)
 		s.db.Put(
-			scope, c.CommitSequence, c.CommitIndex, dataBuf)
-		s.tracker.update(changeSeq, scope)
+			selector, c.CommitSequence, c.CommitIndex, dataBuf)
+		s.tracker.update(changeSeq, selector)
 
 	} else {
 		log.Debugf("Ignoring change %s which we already processed", changeSeq)
@@ -81,13 +81,13 @@ func (s *server) handleChange(c *common.Change, firstChange common.Sequence) com
 	return changeSeq
 }
 
-func getScope(c *common.Change) string {
-	var scope string
+func getSelector(c *common.Change) string {
+	var selector string
 	if c.NewRow != nil {
-		c.NewRow.Get(scopeField, &scope)
+		c.NewRow.Get(selectorColumn, &selector)
 	}
 	if c.OldRow != nil {
-		c.OldRow.Get(scopeField, &scope)
+		c.OldRow.Get(selectorColumn, &selector)
 	}
-	return scope
+	return selector
 }

--- a/changeserver/server.go
+++ b/changeserver/server.go
@@ -35,10 +35,10 @@ const (
 	protoContent      = "application/transicator+protobuf"
 	textContent       = "text/plain"
 	lastSequenceKey   = "_ls"
-	defaultScopeField = "_apid_scope"
+	defaultSelectorColumn = "_change_selector"
 )
 
-var scopeField = defaultScopeField
+var selectorColumn = defaultSelectorColumn
 
 type server struct {
 	db          storage.DB

--- a/changeserver/server_main_test.go
+++ b/changeserver/server_main_test.go
@@ -46,7 +46,7 @@ var listener net.Listener
 var testServer *server
 var db *sql.DB
 var insertStmt *sql.Stmt
-var insertAlterativeScopeStmt *sql.Stmt
+var insertAlterativeSelectorStmt *sql.Stmt
 
 func TestServer(t *testing.T) {
 	if debugTests {
@@ -75,10 +75,10 @@ var _ = BeforeSuite(func() {
 	executeSQL(testTableSQL)
 	executeSQL(testAlternateScopeTableSQL)
 	insertStmt, err = db.Prepare(
-		"insert into changeserver_test (sequence, _apid_scope) values ($1, $2)")
+		"insert into changeserver_test (sequence, _change_selector) values ($1, $2)")
 	Expect(err).Should(Succeed())
 
-	insertAlterativeScopeStmt, err = db.Prepare("insert into changeserver_scope_test(sequence, _different_scope) values ($1, $2)")
+	insertAlterativeSelectorStmt, err = db.Prepare("insert into changeserver_scope_test(sequence, _different_selector) values ($1, $2)")
 	Expect(err).Should(Succeed())
 
 	// Start the server, which will be ready to respond to API calls
@@ -156,13 +156,13 @@ func executeGet(url string) []byte {
 const testTableSQL = `
   create table changeserver_test (
   sequence integer primary key,
-  _apid_scope varchar
+  _change_selector varchar
 )`
 
 const testAlternateScopeTableSQL = `
   create table changeserver_scope_test (
     sequence integer primary key,
-    _different_scope varchar
+    _different_selector varchar
   )
 `
 

--- a/snapshotserver/config.go
+++ b/snapshotserver/config.go
@@ -39,8 +39,8 @@ func setConfigDefaults() {
 	pflag.String("cert", "", "TLS certificate file")
 	viper.SetDefault("cert", "")
 
-	pflag.StringP("scopefield", "S", "", "Set scope field")
-	viper.SetDefault("scopeField", defaultScopeField)
+	pflag.StringP("selectorcolumn", "S", "", "Set selector column")
+	viper.SetDefault("selectorColumn", defaultSelectorColumn)
 
 	pflag.BoolP("config", "C", false, fmt.Sprintf("Use a config file named '%s' located in either /etc/%s/, ~/.%s or ./)", appName, packageName, packageName))
 	pflag.BoolP("debug", "D", false, "Turn on debugging")
@@ -59,7 +59,7 @@ func getConfig() error {
 	viper.BindPFlag("configFile", pflag.Lookup("config"))
 	viper.BindPFlag("debug", pflag.Lookup("debug"))
 	viper.BindPFlag("help", pflag.Lookup("help"))
-	viper.BindPFlag("scopeField", pflag.Lookup("scopefield"))
+	viper.BindPFlag("selectorColumn", pflag.Lookup("selectorcolumn"))
 
 	// Load config values from file
 	if viper.GetBool("configFile") {

--- a/snapshotserver/main.go
+++ b/snapshotserver/main.go
@@ -35,10 +35,10 @@ const (
 	appName     string = "snapshotserver"
 	// Default timeout for individual Postgres transactions
 	defaultPGTimeout  = 30 * time.Second
-	defaultScopeField = "_apid_scope"
+	defaultSelectorColumn = "_change_selector"
 )
 
-var scopeField = defaultScopeField
+var selectorColumn = defaultSelectorColumn
 
 func printUsage() {
 	fmt.Fprintln(os.Stderr, "Usage:")
@@ -83,7 +83,7 @@ func main() {
 	cert := viper.GetString("cert")
 
 	debug := viper.GetBool("debug")
-	scopeFieldParam := viper.GetString("scopeField")
+	selectorColumn := viper.GetString("selectorColumn")
 
 	if pgURL == "" {
 		printUsage()
@@ -98,7 +98,7 @@ func main() {
 		log.SetLevel(log.DebugLevel)
 	}
 
-	scopeField = scopeFieldParam
+	selectorColumn = selectorColumn
 
 	log.Infof("Connecting to Postgres DB %s\n", pgURL)
 	db, err := sql.Open("transicator", pgURL)
@@ -121,7 +121,7 @@ func main() {
 
 	router := httprouter.New()
 
-	router.GET("/scopes/:apidconfigId",
+	router.GET("/scopes/:apidclusterId",
 		func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 			GetScopes(w, r, db, p)
 		})

--- a/snapshotserver/snapshot.go
+++ b/snapshotserver/snapshot.go
@@ -412,11 +412,11 @@ func GenSnapshot(w http.ResponseWriter, r *http.Request) {
 	var changeSelectorParam string
 
 	r.ParseForm()
-	changeSelectorInput := r.URL.Query()["change_selector"]
+	changeSelectorInput := r.URL.Query()["scope"]
 	if len(changeSelectorInput) == 0 {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Header().Set("Content-Type", "text/plain")
-		w.Write([]byte("Must include at least one \"change_selector\" query parameter"))
+		w.Write([]byte("Must include at least one \"scope\" query parameter"))
 		return
 	}
 
@@ -433,7 +433,7 @@ func GenSnapshot(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	for _, selector := range changeSelectorInput {
-		changeSelectorParam += "change_selector=" + selector + "&"
+		changeSelectorParam += "scope=" + selector + "&"
 	}
 	redURL := "/data?" + changeSelectorParam + "type=" + typeParam
 
@@ -447,7 +447,7 @@ DownloadSnapshot downloads and resturns the JSON related to the scope
 func DownloadSnapshot(
 w http.ResponseWriter, r *http.Request,
 db *sql.DB, p httprouter.Params) {
-	scopes := r.URL.Query()["change_selector"]
+	scopes := r.URL.Query()["scope"]
 	if len(scopes) == 0 {
 		log.Errorf("change_selector Missing, Request Ignored")
 		return

--- a/test/combined_main_test.go
+++ b/test/combined_main_test.go
@@ -78,6 +78,6 @@ var tableSQL = `
   create table combined_test(
     id integer primary key,
     value varchar,
-		_apid_scope varchar);
+    _change_selector varchar);
   alter table combined_test replica identity full;
 `

--- a/test/combined_test.go
+++ b/test/combined_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Combined tests", func() {
 
 		// Take a snapshot. Specify the streaming protobuf format.
 		// We will get a 303 and automatically follow the redirect
-		url := fmt.Sprintf("%s/snapshots?change_selector=scope1", snapshotBase)
+		url := fmt.Sprintf("%s/snapshots?scope=scope1", snapshotBase)
 		fmt.Fprintf(GinkgoWriter, "GET %s\n", url)
 		req, err := http.NewRequest("GET", url, nil)
 		Expect(err).Should(Succeed())
@@ -121,7 +121,7 @@ var _ = Describe("Combined tests", func() {
 		Expect(foundTable).Should(BeTrue())
 
 		// Check for changes. There should be none.
-		changes := getChanges(fmt.Sprintf("snapshot=%s&change_selector=scope1",
+		changes := getChanges(fmt.Sprintf("snapshot=%s&scope=scope1",
 			sr.SnapshotInfo()), 0)
 		Expect(changes.Changes).Should(BeEmpty())
 
@@ -130,7 +130,7 @@ var _ = Describe("Combined tests", func() {
 		Expect(err).Should(Succeed())
 
 		// Verify the changes
-		changes = getChanges(fmt.Sprintf("snapshot=%s&change_selector=scope1&since=%s&block=5",
+		changes = getChanges(fmt.Sprintf("snapshot=%s&scope=scope1&since=%s&block=5",
 			sr.SnapshotInfo(), changes.LastSequence), 1)
 		Expect(changes.Changes[0].NewRow["id"]).ShouldNot(BeNil())
 		Expect(changes.Changes[0].NewRow["id"].Value).Should(Equal("4"))
@@ -140,7 +140,7 @@ var _ = Describe("Combined tests", func() {
 		Expect(err).Should(Succeed())
 		Expect(result.RowsAffected()).Should(BeEquivalentTo(1))
 
-		changes = getChanges(fmt.Sprintf("snapshot=%s&change_selector=scope1&since=%s&block=5",
+		changes = getChanges(fmt.Sprintf("snapshot=%s&scope=scope1&since=%s&block=5",
 			sr.SnapshotInfo(), changes.LastSequence), 1)
 		Expect(changes.Changes[0].OldRow["id"]).ShouldNot(BeNil())
 		Expect(changes.Changes[0].OldRow["id"].Value).Should(Equal("1"))

--- a/test/combined_test.go
+++ b/test/combined_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Combined tests", func() {
 
 	It("Combined test", func() {
 		// Insert some data to PG
-		insert, err := db.Prepare("insert into combined_test (id, value, _apid_scope) values ($1, $2, $3)")
+		insert, err := db.Prepare("insert into combined_test (id, value, _change_selector) values ($1, $2, $3)")
 		Expect(err).Should(Succeed())
 		defer insert.Close()
 
@@ -62,7 +62,7 @@ var _ = Describe("Combined tests", func() {
 
 		// Take a snapshot. Specify the streaming protobuf format.
 		// We will get a 303 and automatically follow the redirect
-		url := fmt.Sprintf("%s/snapshots?scope=scope1", snapshotBase)
+		url := fmt.Sprintf("%s/snapshots?change_selector=scope1", snapshotBase)
 		fmt.Fprintf(GinkgoWriter, "GET %s\n", url)
 		req, err := http.NewRequest("GET", url, nil)
 		Expect(err).Should(Succeed())
@@ -121,7 +121,7 @@ var _ = Describe("Combined tests", func() {
 		Expect(foundTable).Should(BeTrue())
 
 		// Check for changes. There should be none.
-		changes := getChanges(fmt.Sprintf("snapshot=%s&scope=scope1",
+		changes := getChanges(fmt.Sprintf("snapshot=%s&change_selector=scope1",
 			sr.SnapshotInfo()), 0)
 		Expect(changes.Changes).Should(BeEmpty())
 
@@ -130,7 +130,7 @@ var _ = Describe("Combined tests", func() {
 		Expect(err).Should(Succeed())
 
 		// Verify the changes
-		changes = getChanges(fmt.Sprintf("snapshot=%s&scope=scope1&since=%s&block=5",
+		changes = getChanges(fmt.Sprintf("snapshot=%s&change_selector=scope1&since=%s&block=5",
 			sr.SnapshotInfo(), changes.LastSequence), 1)
 		Expect(changes.Changes[0].NewRow["id"]).ShouldNot(BeNil())
 		Expect(changes.Changes[0].NewRow["id"].Value).Should(Equal("4"))
@@ -140,7 +140,7 @@ var _ = Describe("Combined tests", func() {
 		Expect(err).Should(Succeed())
 		Expect(result.RowsAffected()).Should(BeEquivalentTo(1))
 
-		changes = getChanges(fmt.Sprintf("snapshot=%s&scope=scope1&since=%s&block=5",
+		changes = getChanges(fmt.Sprintf("snapshot=%s&change_selector=scope1&since=%s&block=5",
 			sr.SnapshotInfo(), changes.LastSequence), 1)
 		Expect(changes.Changes[0].OldRow["id"]).ShouldNot(BeNil())
 		Expect(changes.Changes[0].OldRow["id"].Value).Should(Equal("1"))


### PR DESCRIPTION
…PIs have been changed to accept 'change_selector' param instead of 'scope'.