### PR TITLE
tweak: add txid to header in snapshot response for sqlite format

### DIFF
--- a/snapshotserver/sqlite.go
+++ b/snapshotserver/sqlite.go
@@ -79,6 +79,13 @@ func WriteSqliteSnapshot(scopes []string, db *sql.DB, w http.ResponseWriter, r *
 		sendAPIError(http.StatusInternalServerError, err.Error(), w, r)
 		return err
 	}
+	// put tx id into header
+	row := pgTx.QueryRow("select txid_current_snapshot()")
+	var txId string
+	err = row.Scan(&txId)
+	if err == nil {
+		w.Header().Set("transicator-snapshot-txid", txId)
+	}
 
 	// For each table, update the DB
 	for tid, pgTable := range tables {


### PR DESCRIPTION
the nuances of apid make it easier to work with this response if the txid is in the headers, so that it does not need to open the db, read from the table, then rename the file (apid wants dbs to be named according to txid).

This is the path of least resistance