### PR TITLE
tweak: add txid to header in snapshot response for sqlite format

### DIFF
--- a/snapshotserver/snapshot_api_test.go
+++ b/snapshotserver/snapshot_api_test.go
@@ -232,6 +232,15 @@ var _ = Describe("Snapshot API Tests", func() {
 		Expect(r["created_by"]).Should(Equal(1))
 		Expect(r["id"]).Should(Equal(2))
 		Expect(r["_change_selector"]).Should(Equal(2))
+		
+		row = sdb.QueryRow(
+			"select value from _transicator_metadata where key = 'snapshot'")
+		var snap string
+		err = row.Scan(&snap)
+
+		Expect(err).Should(Succeed())
+		Expect(resp.Header.Get("Transicator-Snapshot-TXID")).To(Equal(snap))
+
 	})
 
 	It("SQLite snapshot empty scope", func() {

--- a/snapshotserver/sqlite.go
+++ b/snapshotserver/sqlite.go
@@ -79,6 +79,13 @@ func WriteSqliteSnapshot(scopes []string, db *sql.DB, w http.ResponseWriter, r *
 		sendAPIError(http.StatusInternalServerError, err.Error(), w, r)
 		return err
 	}
+	// put tx id into header
+	row := pgTx.QueryRow("select txid_current_snapshot()")
+	var txId string
+	err = row.Scan(&txId)
+	if err == nil {
+		w.Header().Set("transicator-snapshot-txid", txId)
+	}
 
 	// For each table, update the DB
 	for tid, pgTable := range tables {

--- a/snapshotserver/sqlite.go
+++ b/snapshotserver/sqlite.go
@@ -84,7 +84,7 @@ func WriteSqliteSnapshot(scopes []string, db *sql.DB, w http.ResponseWriter, r *
 	var txId string
 	err = row.Scan(&txId)
 	if err == nil {
-		w.Header().Set("transicator-snapshot-txid", txId)
+		w.Header().Set("Transicator-Snapshot-TXID", txId)
 	}
 
 	// For each table, update the DB


### PR DESCRIPTION
apid needs this to work efficiently with sqlite snapshots

this is the path of least resistance