### PR TITLE
Add a mock PG server for testing client options

### DIFF
--- a/cmd/mockpgserver/main.go
+++ b/cmd/mockpgserver/main.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2017 The Transicator Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/apigee-labs/transicator/pgclient"
+)
+
+func main() {
+	var port int
+
+	flag.IntVar(&port, "p", 5432, "Port to listen on")
+	flag.Parse()
+	if !flag.Parsed() {
+		flag.Usage()
+		return
+	}
+
+	mock, err := pgclient.NewMockServer(port)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating server: %s\n", err)
+		return
+	}
+
+	fmt.Printf("Mock server listening at %s\n", mock.Address())
+
+	stopChan := make(chan bool)
+	<-stopChan
+}

--- a/pgclient/connection_test.go
+++ b/pgclient/connection_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package pgclient
 
 import (
+	"database/sql"
 	"fmt"
 
 	. "github.com/onsi/ginkgo"
@@ -23,37 +24,74 @@ import (
 )
 
 var _ = Describe("Connection Tests", func() {
-	It("Basic Connect", func() {
-		if dbURL == "" {
-			return
-		}
-		conn, err := Connect(dbURL)
-		Expect(err).Should(Succeed())
-		Expect(conn).ShouldNot(BeNil())
-		conn.Close()
+	var mock *MockServer
+
+	BeforeEach(func() {
+		mock = NewMockServer()
+	})
+
+	AfterEach(func() {
+		mock.Stop()
+	})
+
+	It("Trusted Connect", func() {
+		mock.Start(0)
+		tryConnect(fmt.Sprintf("postgres://mock@%s/turtle", mock.Address()))
+		// Connect with TLS required should fail
+		failToConnect(fmt.Sprintf("postgres://mock@%s/turtle?ssl=true", mock.Address()))
 	})
 
 	It("Connect to bad host", func() {
-		_, err := Connect("postgres://badhost:9999/postgres")
-		Expect(err).ShouldNot(Succeed())
+		failToConnect("postgres://badhost:9999/postgres")
 	})
 
-	It("Connect to bad database", func() {
-		if dbURL == "" {
-			return
-		}
-		_, err := Connect("postgres://postgres@localhost/baddatabase")
-		Expect(err).ShouldNot(Succeed())
-		fmt.Fprintf(GinkgoWriter, "Error from database: %s\n", err)
+	It("Connect to wrong database", func() {
+		mock.Start(0)
+		failToConnect(fmt.Sprintf("postgres://mock@%s/wrongdatabase", mock.Address()))
 	})
 
-	PIt("Basic Connect with SSL", func() {
-		if dbURL == "" {
-			return
-		}
-		conn, err := Connect(dbURL + "?ssl=true")
+	It("Cleartext Connect", func() {
+		mock.SetAuthType(MockClear)
+		mock.Start(0)
+		tryConnect(fmt.Sprintf("postgres://mock:mocketty@%s/turtle", mock.Address()))
+		failToConnect(fmt.Sprintf("postgres://mock@%s/turtle", mock.Address()))
+		failToConnect(fmt.Sprintf("postgres://mock:notthepassword@%s/turtle", mock.Address()))
+	})
+
+	It("MD5 Connect", func() {
+		mock.SetAuthType(MockMD5)
+		mock.Start(0)
+		tryConnect(fmt.Sprintf("postgres://mock:mocketty@%s/turtle", mock.Address()))
+		failToConnect(fmt.Sprintf("postgres://mock@%s/turtle", mock.Address()))
+		failToConnect(fmt.Sprintf("postgres://mock:notthepassword@%s/turtle", mock.Address()))
+	})
+
+	It("Connect with TLS", func() {
+		mock.SetAuthType(MockMD5)
+		mock.SetTLSInfo("../test/keys/clearcert.pem", "../test/keys/clearkey.pem")
+		err := mock.Start(0)
 		Expect(err).Should(Succeed())
-		Expect(conn).ShouldNot(BeNil())
-		conn.Close()
+		// Connect with no TLS -- should still work
+		tryConnect(fmt.Sprintf("postgres://mock:mocketty@%s/turtle", mock.Address()))
+		// Connect with TLS required -- should also still work
+		tryConnect(fmt.Sprintf("postgres://mock:mocketty@%s/turtle?ssl=true", mock.Address()))
 	})
 })
+
+func tryConnect(url string) {
+	db, err := sql.Open("transicator", url)
+	Expect(err).Should(Succeed())
+	err = db.Ping()
+	Expect(err).Should(Succeed())
+	err = db.Close()
+	Expect(err).Should(Succeed())
+}
+
+func failToConnect(url string) {
+	db, err := sql.Open("transicator", url)
+	Expect(err).Should(Succeed())
+	err = db.Ping()
+	Expect(err).ShouldNot(Succeed())
+	err = db.Close()
+	Expect(err).Should(Succeed())
+}

--- a/pgclient/driver_test.go
+++ b/pgclient/driver_test.go
@@ -342,6 +342,7 @@ var _ = Describe("Driver tests", func() {
 		defer idb.Close()
 
 		idb.Driver().(*PgDriver).SetIsolationLevel("serializable")
+		defer idb.Driver().(*PgDriver).SetIsolationLevel("")
 
 		tx, err := idb.Begin()
 		Expect(err).Should(Succeed())

--- a/pgclient/encoding.go
+++ b/pgclient/encoding.go
@@ -29,7 +29,7 @@ length.
 */
 type OutputMessage struct {
 	buf     *bytes.Buffer
-	msgType PgOutputType
+	msgType int
 	hasType bool
 }
 
@@ -39,7 +39,18 @@ NewOutputMessage constructs a new message with the given type byte
 func NewOutputMessage(msgType PgOutputType) *OutputMessage {
 	return &OutputMessage{
 		buf:     &bytes.Buffer{},
-		msgType: msgType,
+		msgType: int(msgType),
+		hasType: true,
+	}
+}
+
+/*
+NewServerOutputMessage constructs a new message with the given type byte
+*/
+func NewServerOutputMessage(msgType PgInputType) *OutputMessage {
+	return &OutputMessage{
+		buf:     &bytes.Buffer{},
+		msgType: int(msgType),
 		hasType: true,
 	}
 }
@@ -59,7 +70,15 @@ Type returns the message type byte from the message that was passed in to
 the "NewOutputMessage" function.
 */
 func (m *OutputMessage) Type() PgOutputType {
-	return m.msgType
+	return PgOutputType(m.msgType)
+}
+
+/*
+ServerType returns the message type byte from the message that was passed in to
+the "NewOutputMessage" function if we're a server
+*/
+func (m *OutputMessage) ServerType() PgInputType {
+	return PgInputType(m.msgType)
 }
 
 /*
@@ -160,7 +179,7 @@ message.
 */
 type InputMessage struct {
 	buf     *bytes.Buffer
-	msgType PgInputType
+	msgType int
 }
 
 /*
@@ -170,7 +189,18 @@ which must be the correct length for the message.
 func NewInputMessage(msgType PgInputType, b []byte) *InputMessage {
 	return &InputMessage{
 		buf:     bytes.NewBuffer(b),
-		msgType: msgType,
+		msgType: int(msgType),
+	}
+}
+
+/*
+NewServerInputMessage generates a new input message from the specified byte array,
+which must be the correct length for the message.
+*/
+func NewServerInputMessage(msgType PgOutputType, b []byte) *InputMessage {
+	return &InputMessage{
+		buf:     bytes.NewBuffer(b),
+		msgType: int(msgType),
 	}
 }
 
@@ -179,7 +209,15 @@ Type returns the message type byte from the message that was passed in to
 the "NewInputMessage" function.
 */
 func (m *InputMessage) Type() PgInputType {
-	return m.msgType
+	return PgInputType(m.msgType)
+}
+
+/*
+ServerType returns the message type byte from the message that was passed in to
+the "NewInputMessage" function when we're a server.
+*/
+func (m *InputMessage) ServerType() PgOutputType {
+	return PgOutputType(m.msgType)
 }
 
 /*

--- a/pgclient/mockserver.go
+++ b/pgclient/mockserver.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2017 The Transicator Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package pgclient
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+const (
+	mockUserName     = "mock"
+	mockDatabaseName = "turtle"
+)
+
+type mockState int
+
+const (
+	mockIdle mockState = 1
+)
+
+/*
+A MockServer is a server that implements much of the Postgres wire protocol.
+It is used for unit testing of the postgres client, especially where
+we are testing the many different SSL connection options.
+*/
+type MockServer struct {
+	listener net.Listener
+}
+
+/*
+NewMockServer starts a new server in the current process, listening on the
+specified port.
+*/
+func NewMockServer(port int) (s *MockServer, err error) {
+	var listener net.Listener
+	listener, err = net.ListenTCP("tcp", &net.TCPAddr{
+		Port: port,
+	})
+	if err != nil {
+		return
+	}
+
+	s = &MockServer{
+		listener: listener,
+	}
+	go s.acceptLoop()
+
+	return
+}
+
+/*
+Address returns the listen address in host:port format.
+*/
+func (m *MockServer) Address() string {
+	return m.listener.Addr().String()
+}
+
+/*
+Stop stops the server listening for new connections.
+*/
+func (m *MockServer) Stop() {
+	m.listener.Close()
+}
+
+func (m *MockServer) acceptLoop() {
+	for {
+		conn, err := m.listener.Accept()
+		if err != nil {
+			return
+		}
+		go m.connectLoop(conn)
+	}
+}
+
+func (m *MockServer) connectLoop(c net.Conn) {
+	defer c.Close()
+
+	startup, err := readMockMessage(c, true)
+	if err != nil {
+		log.Errorf("Error reading startup message: %s\n", err)
+		return
+	}
+
+	protoVersion, err := startup.ReadInt32()
+	if err != nil {
+		log.Error("Can't read protocol version")
+		return
+	}
+	if protoVersion != protocolVersion {
+		sendError(c, fmt.Sprintf("Invalid read protocol version %d\n", protoVersion))
+		return
+	}
+
+	var paramName, paramVal string
+	for {
+		paramName, err = startup.ReadString()
+		if err != nil {
+			return
+		}
+		if paramName == "" {
+			break
+		}
+		paramVal, err = startup.ReadString()
+		if err != nil {
+			return
+		}
+
+		if paramName == "user" {
+			if paramVal != mockUserName {
+				sendError(c, fmt.Sprintf("Invalid user name %s", paramVal))
+				return
+			}
+		}
+		if paramName == "database" {
+			if paramVal != mockDatabaseName {
+				sendError(c, fmt.Sprintf("Invalid database name %s\n", paramVal))
+				return
+			}
+		}
+	}
+
+	out := NewOutputMessage(AuthenticationResponse)
+	out.WriteInt32(0)
+	c.Write(out.Encode())
+	sendReady(c)
+
+	m.readLoop(c)
+}
+
+func (m *MockServer) readLoop(c net.Conn) {
+	state := mockIdle
+
+	for {
+		msg, err := readMockMessage(c, false)
+		if err != nil {
+			return
+		}
+
+		switch state {
+		case mockIdle:
+			m.readIdle(c, msg)
+		}
+	}
+}
+
+func (m *MockServer) readIdle(c net.Conn, msg *InputMessage) {
+	switch msg.Type() {
+	case Query:
+		sendError(c, "Invalid SQL")
+		sendReady(c)
+	default:
+		sendError(c, fmt.Sprintf("Invalid message %s", msg.Type()))
+		sendReady(c)
+	}
+}
+
+func readMockMessage(c net.Conn, isStartup bool) (msg *InputMessage, err error) {
+	var hdr []byte
+	if isStartup {
+		hdr = make([]byte, 4)
+	} else {
+		hdr = make([]byte, 5)
+	}
+
+	_, err = io.ReadFull(c, hdr)
+	if err != nil {
+		return
+	}
+
+	hdrBuf := bytes.NewBuffer(hdr)
+	var msgType PgMessageType
+
+	if !isStartup {
+		var msgTypeVal byte
+		msgTypeVal, err = hdrBuf.ReadByte()
+		if err != nil {
+			return
+		}
+		msgType = PgMessageType(msgTypeVal)
+	}
+
+	var msgLen int32
+	err = binary.Read(hdrBuf, networkByteOrder, &msgLen)
+	if err != nil {
+		return
+	}
+
+	if msgLen < 4 {
+		err = fmt.Errorf("Invalid message length %d", msgLen)
+		return
+	}
+
+	bodBuf := make([]byte, msgLen-4)
+	_, err = io.ReadFull(c, bodBuf)
+	if err != nil {
+		return
+	}
+
+	msg = NewInputMessage(msgType, bodBuf)
+	return
+}
+
+func sendError(c net.Conn, msg string) {
+	out := NewOutputMessage(ErrorResponse)
+	out.WriteByte('S')
+	out.WriteString("FATAL")
+	out.WriteByte('M')
+	out.WriteString(msg)
+	c.Write(out.Encode())
+}
+
+func sendReady(c net.Conn) {
+	out := NewOutputMessage(ReadyForQuery)
+	out.WriteByte('I')
+	c.Write(out.Encode())
+}

--- a/pgclient/mockserver_test.go
+++ b/pgclient/mockserver_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2017 The Transicator Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pgclient
+
+import (
+	"database/sql"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Mock server tests", func() {
+	var server *MockServer
+
+	BeforeEach(func() {
+		var err error
+
+		server, err = NewMockServer(0)
+		Expect(err).Should(Succeed())
+	})
+
+	AfterEach(func() {
+		server.Stop()
+	})
+
+	It("Connect", func() {
+		url := fmt.Sprintf("postgres://mock@%s/turtle", server.Address())
+		db, err := sql.Open("transicator", url)
+		Expect(err).Should(Succeed())
+		err = db.Ping()
+		Expect(err).Should(Succeed())
+		err = db.Close()
+		Expect(err).Should(Succeed())
+	})
+
+	It("Bad Exec", func() {
+		url := fmt.Sprintf("postgres://mock@%s/turtle", server.Address())
+		db, err := sql.Open("transicator", url)
+		Expect(err).Should(Succeed())
+		_, err = db.Exec("This is not sql")
+		Expect(err).ShouldNot(Succeed())
+		err = db.Close()
+		Expect(err).Should(Succeed())
+	})
+
+	It("Insert", func() {
+		url := fmt.Sprintf("postgres://mock@%s/turtle", server.Address())
+		db, err := sql.Open("transicator", url)
+		Expect(err).Should(Succeed())
+		_, err = db.Exec("insert into mock values('foo', 'bar')")
+		Expect(err).Should(Succeed())
+		err = db.Close()
+		Expect(err).Should(Succeed())
+	})
+})

--- a/pgclient/mockserver_test.go
+++ b/pgclient/mockserver_test.go
@@ -28,9 +28,8 @@ var _ = Describe("Mock server tests", func() {
 	var server *MockServer
 
 	BeforeEach(func() {
-		var err error
-
-		server, err = NewMockServer(0)
+		server = NewMockServer()
+		err := server.Start(0)
 		Expect(err).Should(Succeed())
 	})
 
@@ -62,7 +61,7 @@ var _ = Describe("Mock server tests", func() {
 		url := fmt.Sprintf("postgres://mock@%s/turtle", server.Address())
 		db, err := sql.Open("transicator", url)
 		Expect(err).Should(Succeed())
-		_, err = db.Exec("insert into mock values('foo', 'bar')")
+		_, err = db.Exec("insert into mock values ('foo', 'bar')")
 		Expect(err).Should(Succeed())
 		err = db.Close()
 		Expect(err).Should(Succeed())


### PR DESCRIPTION
Rather than leave critical PG client features like TLS config and password authentication untested without having lots of PG servers available, write a small mock server that implements those parts of the PG wire protocol.

(Historical note -- we have our own PG client rather than lib/pg because that has made the replication protocol easier to support, as it's easier to control our own thing in this particular case, or at least it was a year ago.