### PR TITLE
Support more parameters for PG URL to match C library

### DIFF
--- a/cmd/mockpgserver/main.go
+++ b/cmd/mockpgserver/main.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2017 The Transicator Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/apigee-labs/transicator/pgclient"
+)
+
+func main() {
+	var port int
+
+	flag.IntVar(&port, "p", 5432, "Port to listen on")
+	flag.Parse()
+	if !flag.Parsed() {
+		flag.Usage()
+		return
+	}
+
+	mock, err := pgclient.NewMockServer(port)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating server: %s\n", err)
+		return
+	}
+
+	fmt.Printf("Mock server listening at %s\n", mock.Address())
+
+	stopChan := make(chan bool)
+	<-stopChan
+}

--- a/pgclient/connection.go
+++ b/pgclient/connection.go
@@ -45,8 +45,7 @@ A PgConnection represents a connection to the database.
 */
 type PgConnection struct {
 	conn        net.Conn
-	host        string
-	port        int
+	connParams  *connectInfo
 	readTimeout time.Duration
 	pid         int32
 	key         int32
@@ -57,9 +56,11 @@ Connect to the database. "host" must be a "host:port" pair, "user" and "database
 must contain the appropriate user name and database name, and "opts" contains
 any other keys and values to send to the database.
 
-The connect string works the same way as "psql," or the JDBC driver:
+The connect stringsupports the style of URL that the standard "libpq"
+supports.
+https://www.postgresql.org/docs/9.6/static/libpq-connect.html
 
-postgres://[user[:password]@]hostname[:port]/[database]?ssl=[true|false]&param=val&param=val
+postgres://[user[:password]@]hostname[:port]/[database]?sslmode=[require|allow|prefer|disable]&param=val&param=val
 */
 func Connect(connect string) (*PgConnection, error) {
 	ci, err := parseConnectString(connect)
@@ -67,14 +68,31 @@ func Connect(connect string) (*PgConnection, error) {
 		return nil, err
 	}
 
-	conn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", ci.host, ci.port))
-	if err != nil {
-		return nil, err
+	if ci.ssl == sslVerifyCA || ci.ssl == sslVerifyFull {
+		return nil, errors.New("SSL verification options not supported")
 	}
+
 	c := &PgConnection{
-		conn: conn,
-		host: ci.host,
-		port: ci.port,
+		connParams: ci,
+	}
+
+	err = c.startConnection(ci.ssl)
+	if err != nil {
+		if ci.ssl == sslAllow {
+			// We tried non-SSL and it failed completely. Try again with SSL.
+			err = c.startConnection(sslRequire)
+		} else if ci.ssl == sslPrefer {
+			// We tried SSL and there was a handshake failure. Try again without.
+			err = c.startConnection(sslDisable)
+		}
+	}
+	return c, err
+}
+
+func (c *PgConnection) startConnection(ssl sslMode) error {
+	conn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", c.connParams.host, c.connParams.port))
+	if err != nil {
+		return err
 	}
 
 	success := false
@@ -83,46 +101,64 @@ func Connect(connect string) (*PgConnection, error) {
 			conn.Close()
 		}
 	}()
+	c.conn = conn
 
-	if ci.ssl {
-		err = c.startSSL(ci)
+	if ssl == sslPrefer || ssl == sslRequire {
+		var sslSupported bool
+		sslSupported, err = c.startSSL()
 		if err != nil {
-			return nil, err
+			return err
+		}
+		if ssl == sslRequire && !sslSupported {
+			return errors.New("SSL is not supported by the server")
+		}
+		// At this point, it's OK if SSL is not supported
+		if sslSupported {
+			err = c.sslHandshake()
+			if err != nil {
+				return err
+			}
 		}
 	}
 
+	// At this point we're connected and handshaked to SSL if necessary
+
 	// Send "Startup" message
-	err = c.sendStartup(ci)
+	err = c.sendStartup()
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	// Loop here later for challenge-response
-	err = c.authenticationLoop(ci)
+	// Loop here for challenge-response
+	err = c.authenticationLoop()
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// Finish up with receiving parameters and all that
-	err = c.finishConnect(ci)
+	err = c.finishConnect()
 	if err == nil {
 		success = true
 	}
-	return c, err
+	return err
 }
 
 func (c *PgConnection) setReadTimeout(t time.Duration) {
 	c.readTimeout = t
 }
 
-func (c *PgConnection) startSSL(ci *connectInfo) error {
+/*
+startSSL sends the Postgres message to start an SSL session and then returns
+true if SSL is supported, and an error if we cannot get that information.
+*/
+func (c *PgConnection) startSSL() (bool, error) {
 	log.Debug("Starting SSL on connection")
 	sslStartup := NewStartupMessage()
 	sslStartup.WriteInt32(sslMagicNumber)
 
 	err := c.WriteMessage(sslStartup)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// Just read one byte to see if we support SSL:
@@ -130,24 +166,24 @@ func (c *PgConnection) startSSL(ci *connectInfo) error {
 	_, err = io.ReadFull(c.conn, sslStatus)
 	if err != nil {
 		log.Debug("Error on read")
-		return err
+		return false, err
 	}
 
 	log.Debugf("Got back %v", sslStatus[0])
 	switch sslStatus[0] {
 	case 'S':
-		return c.sslHandshake(ci)
+		return true, nil
 	case 'N':
-		return errors.New("Server does not support SSL")
+		return false, nil
 	default:
-		return fmt.Errorf("Invalid SSL handshake from server: %v", sslStatus[0])
+		return false, fmt.Errorf("Invalid SSL handshake from server: %v", sslStatus[0])
 	}
 }
 
-func (c *PgConnection) sslHandshake(ci *connectInfo) error {
+func (c *PgConnection) sslHandshake() error {
 	// Always do TLS without verifying the server
 	tlsConfig := &tls.Config{
-		ServerName:         ci.host,
+		ServerName:         c.connParams.host,
 		InsecureSkipVerify: true,
 	}
 
@@ -165,15 +201,15 @@ func (c *PgConnection) sslHandshake(ci *connectInfo) error {
 	return nil
 }
 
-func (c *PgConnection) sendStartup(ci *connectInfo) error {
+func (c *PgConnection) sendStartup() error {
 	startup := NewStartupMessage()
 	startup.WriteInt32(protocolVersion)
 	startup.WriteString("user")
-	startup.WriteString(ci.user)
+	startup.WriteString(c.connParams.user)
 	startup.WriteString("database")
-	startup.WriteString(ci.database)
+	startup.WriteString(c.connParams.database)
 
-	for k, v := range ci.options {
+	for k, v := range c.connParams.options {
 		startup.WriteString(k)
 		startup.WriteString(v)
 	}
@@ -183,7 +219,7 @@ func (c *PgConnection) sendStartup(ci *connectInfo) error {
 	return c.WriteMessage(startup)
 }
 
-func (c *PgConnection) authenticationLoop(ci *connectInfo) error {
+func (c *PgConnection) authenticationLoop() error {
 	authDone := false
 	for !authDone {
 		im, err := c.ReadMessage()
@@ -209,14 +245,14 @@ func (c *PgConnection) authenticationLoop(ci *connectInfo) error {
 			// "password"
 			log.Debug("Sending password in response")
 			pm := NewOutputMessage(PasswordMessage)
-			pm.WriteString(ci.creds)
+			pm.WriteString(c.connParams.creds)
 			c.WriteMessage(pm)
 		case 5:
 			// "md5"
 			log.Debug("Sending MD5 password as response")
 			salt, _ := im.ReadBytes(4)
 			pm := NewOutputMessage(PasswordMessage)
-			pm.WriteString(passwordMD5(ci.user, ci.creds, salt))
+			pm.WriteString(passwordMD5(c.connParams.user, c.connParams.creds, salt))
 			c.WriteMessage(pm)
 		default:
 			// Currently not supporting other schemes like Kerberos...
@@ -226,7 +262,7 @@ func (c *PgConnection) authenticationLoop(ci *connectInfo) error {
 	return nil
 }
 
-func (c *PgConnection) finishConnect(ci *connectInfo) error {
+func (c *PgConnection) finishConnect() error {
 	// Loop to wait for "ready" status
 	for {
 		im, err := c.readStandardMessage()
@@ -416,7 +452,7 @@ be cancelled.
 */
 func (c *PgConnection) sendCancel() error {
 	log.Debugf("Sending cancel to PID %d", c.pid)
-	conn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", c.host, c.port))
+	conn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", c.connParams.host, c.connParams.port))
 	if err != nil {
 		return err
 	}

--- a/pgclient/connection_test.go
+++ b/pgclient/connection_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Connection Tests", func() {
 	})
 
 	It("Connect to bad host", func() {
-		failToConnect("postgres://badhost:9999/postgres")
+		failToConnect("postgres://badhost:9999/postgres?connect_timeout=1")
 	})
 
 	It("Connect to wrong database", func() {
@@ -53,7 +53,7 @@ var _ = Describe("Connection Tests", func() {
 	It("Cleartext Connect", func() {
 		mock.SetAuthType(MockClear)
 		mock.Start(0)
-		tryConnect(fmt.Sprintf("postgres://mock:mocketty@%s/turtle", mock.Address()))
+		tryConnect(fmt.Sprintf("postgres://mock:mocketty@%s/turtle?keepalives=1&keepalives_idle=1", mock.Address()))
 		failToConnect(fmt.Sprintf("postgres://mock@%s/turtle", mock.Address()))
 		failToConnect(fmt.Sprintf("postgres://mock:notthepassword@%s/turtle", mock.Address()))
 	})

--- a/pgclient/connection_test.go
+++ b/pgclient/connection_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package pgclient
 
 import (
+	"database/sql"
 	"fmt"
 
 	. "github.com/onsi/ginkgo"
@@ -23,37 +24,74 @@ import (
 )
 
 var _ = Describe("Connection Tests", func() {
-	It("Basic Connect", func() {
-		if dbURL == "" {
-			return
-		}
-		conn, err := Connect(dbURL)
-		Expect(err).Should(Succeed())
-		Expect(conn).ShouldNot(BeNil())
-		conn.Close()
+	var mock *MockServer
+
+	BeforeEach(func() {
+		mock = NewMockServer()
+	})
+
+	AfterEach(func() {
+		mock.Stop()
+	})
+
+	It("Trusted Connect", func() {
+		mock.Start(0)
+		tryConnect(fmt.Sprintf("postgres://mock@%s/turtle", mock.Address()))
+		// Connect with TLS required should fail
+		failToConnect(fmt.Sprintf("postgres://mock@%s/turtle?ssl=true", mock.Address()))
 	})
 
 	It("Connect to bad host", func() {
-		_, err := Connect("postgres://badhost:9999/postgres")
-		Expect(err).ShouldNot(Succeed())
+		failToConnect("postgres://badhost:9999/postgres")
 	})
 
-	It("Connect to bad database", func() {
-		if dbURL == "" {
-			return
-		}
-		_, err := Connect("postgres://postgres@localhost/baddatabase")
-		Expect(err).ShouldNot(Succeed())
-		fmt.Fprintf(GinkgoWriter, "Error from database: %s\n", err)
+	It("Connect to wrong database", func() {
+		mock.Start(0)
+		failToConnect(fmt.Sprintf("postgres://mock@%s/wrongdatabase", mock.Address()))
 	})
 
-	PIt("Basic Connect with SSL", func() {
-		if dbURL == "" {
-			return
-		}
-		conn, err := Connect(dbURL + "?ssl=true")
+	It("Cleartext Connect", func() {
+		mock.SetAuthType(MockClear)
+		mock.Start(0)
+		tryConnect(fmt.Sprintf("postgres://mock:mocketty@%s/turtle", mock.Address()))
+		failToConnect(fmt.Sprintf("postgres://mock@%s/turtle", mock.Address()))
+		failToConnect(fmt.Sprintf("postgres://mock:notthepassword@%s/turtle", mock.Address()))
+	})
+
+	It("MD5 Connect", func() {
+		mock.SetAuthType(MockMD5)
+		mock.Start(0)
+		tryConnect(fmt.Sprintf("postgres://mock:mocketty@%s/turtle", mock.Address()))
+		failToConnect(fmt.Sprintf("postgres://mock@%s/turtle", mock.Address()))
+		failToConnect(fmt.Sprintf("postgres://mock:notthepassword@%s/turtle", mock.Address()))
+	})
+
+	It("Connect with TLS", func() {
+		mock.SetAuthType(MockMD5)
+		mock.SetTLSInfo("../test/keys/clearcert.pem", "../test/keys/clearkey.pem")
+		err := mock.Start(0)
 		Expect(err).Should(Succeed())
-		Expect(conn).ShouldNot(BeNil())
-		conn.Close()
+		// Connect with no TLS -- should still work
+		tryConnect(fmt.Sprintf("postgres://mock:mocketty@%s/turtle", mock.Address()))
+		// Connect with TLS required -- should also still work
+		tryConnect(fmt.Sprintf("postgres://mock:mocketty@%s/turtle?ssl=true", mock.Address()))
 	})
 })
+
+func tryConnect(url string) {
+	db, err := sql.Open("transicator", url)
+	Expect(err).Should(Succeed())
+	err = db.Ping()
+	Expect(err).Should(Succeed())
+	err = db.Close()
+	Expect(err).Should(Succeed())
+}
+
+func failToConnect(url string) {
+	db, err := sql.Open("transicator", url)
+	Expect(err).Should(Succeed())
+	err = db.Ping()
+	Expect(err).ShouldNot(Succeed())
+	err = db.Close()
+	Expect(err).Should(Succeed())
+}

--- a/pgclient/driver_test.go
+++ b/pgclient/driver_test.go
@@ -342,6 +342,7 @@ var _ = Describe("Driver tests", func() {
 		defer idb.Close()
 
 		idb.Driver().(*PgDriver).SetIsolationLevel("serializable")
+		defer idb.Driver().(*PgDriver).SetIsolationLevel("")
 
 		tx, err := idb.Begin()
 		Expect(err).Should(Succeed())

--- a/pgclient/encoding.go
+++ b/pgclient/encoding.go
@@ -29,7 +29,7 @@ length.
 */
 type OutputMessage struct {
 	buf     *bytes.Buffer
-	msgType PgOutputType
+	msgType int
 	hasType bool
 }
 
@@ -39,7 +39,18 @@ NewOutputMessage constructs a new message with the given type byte
 func NewOutputMessage(msgType PgOutputType) *OutputMessage {
 	return &OutputMessage{
 		buf:     &bytes.Buffer{},
-		msgType: msgType,
+		msgType: int(msgType),
+		hasType: true,
+	}
+}
+
+/*
+NewServerOutputMessage constructs a new message with the given type byte
+*/
+func NewServerOutputMessage(msgType PgInputType) *OutputMessage {
+	return &OutputMessage{
+		buf:     &bytes.Buffer{},
+		msgType: int(msgType),
 		hasType: true,
 	}
 }
@@ -59,7 +70,15 @@ Type returns the message type byte from the message that was passed in to
 the "NewOutputMessage" function.
 */
 func (m *OutputMessage) Type() PgOutputType {
-	return m.msgType
+	return PgOutputType(m.msgType)
+}
+
+/*
+ServerType returns the message type byte from the message that was passed in to
+the "NewOutputMessage" function if we're a server
+*/
+func (m *OutputMessage) ServerType() PgInputType {
+	return PgInputType(m.msgType)
 }
 
 /*
@@ -160,7 +179,7 @@ message.
 */
 type InputMessage struct {
 	buf     *bytes.Buffer
-	msgType PgInputType
+	msgType int
 }
 
 /*
@@ -170,7 +189,18 @@ which must be the correct length for the message.
 func NewInputMessage(msgType PgInputType, b []byte) *InputMessage {
 	return &InputMessage{
 		buf:     bytes.NewBuffer(b),
-		msgType: msgType,
+		msgType: int(msgType),
+	}
+}
+
+/*
+NewServerInputMessage generates a new input message from the specified byte array,
+which must be the correct length for the message.
+*/
+func NewServerInputMessage(msgType PgOutputType, b []byte) *InputMessage {
+	return &InputMessage{
+		buf:     bytes.NewBuffer(b),
+		msgType: int(msgType),
 	}
 }
 
@@ -179,7 +209,15 @@ Type returns the message type byte from the message that was passed in to
 the "NewInputMessage" function.
 */
 func (m *InputMessage) Type() PgInputType {
-	return m.msgType
+	return PgInputType(m.msgType)
+}
+
+/*
+ServerType returns the message type byte from the message that was passed in to
+the "NewInputMessage" function when we're a server.
+*/
+func (m *InputMessage) ServerType() PgOutputType {
+	return PgOutputType(m.msgType)
 }
 
 /*

--- a/pgclient/mockserver.go
+++ b/pgclient/mockserver.go
@@ -63,6 +63,7 @@ type MockServer struct {
 	mockTable map[string]string
 	authType  MockAuth
 	tlsConfig *tls.Config
+	forceTLS  bool
 }
 
 /*
@@ -96,6 +97,13 @@ func (m *MockServer) SetTLSInfo(certFile, keyFile string) error {
 		Certificates: []tls.Certificate{cert},
 	}
 	return nil
+}
+
+/*
+SetForceTLS sets up the server to reject any non-TLS clients.
+*/
+func (m *MockServer) SetForceTLS() {
+	m.forceTLS = true
 }
 
 /*
@@ -176,6 +184,9 @@ func (m *MockServer) connectLoop(c net.Conn) {
 			return
 		}
 		protoVersion, _ = startup.ReadInt32()
+	} else if m.forceTLS {
+		// We will just close any connection that doesn't ask for TLS
+		return
 	}
 
 	if protoVersion != protocolVersion {

--- a/pgclient/mockserver.go
+++ b/pgclient/mockserver.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2017 The Transicator Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package pgclient
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+const (
+	mockUserName     = "mock"
+	mockDatabaseName = "turtle"
+)
+
+type mockState int
+
+const (
+	mockIdle mockState = 1
+)
+
+/*
+A MockServer is a server that implements much of the Postgres wire protocol.
+It is used for unit testing of the postgres client, especially where
+we are testing the many different SSL connection options.
+*/
+type MockServer struct {
+	listener net.Listener
+}
+
+/*
+NewMockServer starts a new server in the current process, listening on the
+specified port.
+*/
+func NewMockServer(port int) (s *MockServer, err error) {
+	var listener net.Listener
+	listener, err = net.ListenTCP("tcp", &net.TCPAddr{
+		Port: port,
+	})
+	if err != nil {
+		return
+	}
+
+	s = &MockServer{
+		listener: listener,
+	}
+	go s.acceptLoop()
+
+	return
+}
+
+/*
+Address returns the listen address in host:port format.
+*/
+func (m *MockServer) Address() string {
+	return m.listener.Addr().String()
+}
+
+/*
+Stop stops the server listening for new connections.
+*/
+func (m *MockServer) Stop() {
+	m.listener.Close()
+}
+
+func (m *MockServer) acceptLoop() {
+	for {
+		conn, err := m.listener.Accept()
+		if err != nil {
+			return
+		}
+		go m.connectLoop(conn)
+	}
+}
+
+func (m *MockServer) connectLoop(c net.Conn) {
+	defer c.Close()
+
+	startup, err := readMockMessage(c, true)
+	if err != nil {
+		log.Errorf("Error reading startup message: %s\n", err)
+		return
+	}
+
+	protoVersion, err := startup.ReadInt32()
+	if err != nil {
+		log.Error("Can't read protocol version")
+		return
+	}
+	if protoVersion != protocolVersion {
+		sendError(c, fmt.Sprintf("Invalid read protocol version %d\n", protoVersion))
+		return
+	}
+
+	var paramName, paramVal string
+	for {
+		paramName, err = startup.ReadString()
+		if err != nil {
+			return
+		}
+		if paramName == "" {
+			break
+		}
+		paramVal, err = startup.ReadString()
+		if err != nil {
+			return
+		}
+
+		if paramName == "user" {
+			if paramVal != mockUserName {
+				sendError(c, fmt.Sprintf("Invalid user name %s", paramVal))
+				return
+			}
+		}
+		if paramName == "database" {
+			if paramVal != mockDatabaseName {
+				sendError(c, fmt.Sprintf("Invalid database name %s\n", paramVal))
+				return
+			}
+		}
+	}
+
+	out := NewOutputMessage(AuthenticationResponse)
+	out.WriteInt32(0)
+	c.Write(out.Encode())
+	sendReady(c)
+
+	m.readLoop(c)
+}
+
+func (m *MockServer) readLoop(c net.Conn) {
+	state := mockIdle
+
+	for {
+		msg, err := readMockMessage(c, false)
+		if err != nil {
+			return
+		}
+
+		switch state {
+		case mockIdle:
+			m.readIdle(c, msg)
+		}
+	}
+}
+
+func (m *MockServer) readIdle(c net.Conn, msg *InputMessage) {
+	switch msg.Type() {
+	case Query:
+		sendError(c, "Invalid SQL")
+		sendReady(c)
+	default:
+		sendError(c, fmt.Sprintf("Invalid message %s", msg.Type()))
+		sendReady(c)
+	}
+}
+
+func readMockMessage(c net.Conn, isStartup bool) (msg *InputMessage, err error) {
+	var hdr []byte
+	if isStartup {
+		hdr = make([]byte, 4)
+	} else {
+		hdr = make([]byte, 5)
+	}
+
+	_, err = io.ReadFull(c, hdr)
+	if err != nil {
+		return
+	}
+
+	hdrBuf := bytes.NewBuffer(hdr)
+	var msgType PgMessageType
+
+	if !isStartup {
+		var msgTypeVal byte
+		msgTypeVal, err = hdrBuf.ReadByte()
+		if err != nil {
+			return
+		}
+		msgType = PgMessageType(msgTypeVal)
+	}
+
+	var msgLen int32
+	err = binary.Read(hdrBuf, networkByteOrder, &msgLen)
+	if err != nil {
+		return
+	}
+
+	if msgLen < 4 {
+		err = fmt.Errorf("Invalid message length %d", msgLen)
+		return
+	}
+
+	bodBuf := make([]byte, msgLen-4)
+	_, err = io.ReadFull(c, bodBuf)
+	if err != nil {
+		return
+	}
+
+	msg = NewInputMessage(msgType, bodBuf)
+	return
+}
+
+func sendError(c net.Conn, msg string) {
+	out := NewOutputMessage(ErrorResponse)
+	out.WriteByte('S')
+	out.WriteString("FATAL")
+	out.WriteByte('M')
+	out.WriteString(msg)
+	c.Write(out.Encode())
+}
+
+func sendReady(c net.Conn) {
+	out := NewOutputMessage(ReadyForQuery)
+	out.WriteByte('I')
+	c.Write(out.Encode())
+}

--- a/pgclient/mockserver_test.go
+++ b/pgclient/mockserver_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2017 The Transicator Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pgclient
+
+import (
+	"database/sql"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Mock server tests", func() {
+	var server *MockServer
+
+	BeforeEach(func() {
+		var err error
+
+		server, err = NewMockServer(0)
+		Expect(err).Should(Succeed())
+	})
+
+	AfterEach(func() {
+		server.Stop()
+	})
+
+	It("Connect", func() {
+		url := fmt.Sprintf("postgres://mock@%s/turtle", server.Address())
+		db, err := sql.Open("transicator", url)
+		Expect(err).Should(Succeed())
+		err = db.Ping()
+		Expect(err).Should(Succeed())
+		err = db.Close()
+		Expect(err).Should(Succeed())
+	})
+
+	It("Bad Exec", func() {
+		url := fmt.Sprintf("postgres://mock@%s/turtle", server.Address())
+		db, err := sql.Open("transicator", url)
+		Expect(err).Should(Succeed())
+		_, err = db.Exec("This is not sql")
+		Expect(err).ShouldNot(Succeed())
+		err = db.Close()
+		Expect(err).Should(Succeed())
+	})
+
+	It("Insert", func() {
+		url := fmt.Sprintf("postgres://mock@%s/turtle", server.Address())
+		db, err := sql.Open("transicator", url)
+		Expect(err).Should(Succeed())
+		_, err = db.Exec("insert into mock values('foo', 'bar')")
+		Expect(err).Should(Succeed())
+		err = db.Close()
+		Expect(err).Should(Succeed())
+	})
+})

--- a/pgclient/mockserver_test.go
+++ b/pgclient/mockserver_test.go
@@ -28,9 +28,8 @@ var _ = Describe("Mock server tests", func() {
 	var server *MockServer
 
 	BeforeEach(func() {
-		var err error
-
-		server, err = NewMockServer(0)
+		server = NewMockServer()
+		err := server.Start(0)
 		Expect(err).Should(Succeed())
 	})
 
@@ -62,7 +61,7 @@ var _ = Describe("Mock server tests", func() {
 		url := fmt.Sprintf("postgres://mock@%s/turtle", server.Address())
 		db, err := sql.Open("transicator", url)
 		Expect(err).Should(Succeed())
-		_, err = db.Exec("insert into mock values('foo', 'bar')")
+		_, err = db.Exec("insert into mock values ('foo', 'bar')")
 		Expect(err).Should(Succeed())
 		err = db.Close()
 		Expect(err).Should(Succeed())


### PR DESCRIPTION
Add parameters to the PG URL that mimick the standard "libpg" (in C) including options for "tlsmode", keep-alive, and timeout.

This changes the default behavior to always try TLS if the server supports it (just like other PG libraries) and to always enable TCP keep alive unless disabled (like other PG libraries).