### PR TITLE
Ignore Index columns from Primary Key map.

### DIFF
--- a/snapshotserver/pgschema.go
+++ b/snapshotserver/pgschema.go
@@ -53,6 +53,7 @@ func enumeratePgTables(tx *sql.Tx) (map[string]*pgTable, error) {
 	and a.attnum > 0
 	and n.nspname = $1
 	and c.relname = $2
+        and i.indisprimary
 	order by a.attnum
 	`)
 	if err != nil {
@@ -123,7 +124,6 @@ func mapPrimaryKeys(s *sql.Stmt, t *pgTable) error {
 	if err != nil {
 		return err
 	}
-
 	for rows.Next() {
 		var name string
 		err = rows.Scan(&name)

--- a/snapshotserver/snapshot_info_test.go
+++ b/snapshotserver/snapshot_info_test.go
@@ -220,6 +220,8 @@ CREATE TABLE transicator_tests.schema_table (
 	_change_selector character varying
 );
 alter table transicator_tests.schema_table replica identity full;
+CREATE INDEX customer_idx_created_at ON public.APP USING btree (created_at);
+CREATE INDEX dev_idx_created_at ON public.DEVELOPER USING btree (created_at);
 `
 
 var _ = Describe("Taking a snapshot", func() {


### PR DESCRIPTION
1)
Added  i.indisprimary to the search clause. https://wiki.postgresql.org/wiki/Retrieve_primary_key_columns

2)
Added Unit testcase to test this scenario and ensure it works. Without this fix, the Primary key test will fail.