### PR TITLE
Add config 'localBindIpAddr' for listening IP addr to bind

### DIFF
--- a/snapshotserver/config.go
+++ b/snapshotserver/config.go
@@ -27,6 +27,8 @@ import (
 SetConfigDefaults sets up Viper for command-line and other processing.
 */
 func SetConfigDefaults() {
+	pflag.StringP("localbindipaddr", "a", "0.0.0.0", "listener IP address")
+	viper.SetDefault("localBindIpAddr", "0.0.0.0")
 	pflag.IntP("port", "p", -1, "HTTP Binding port")
 	viper.SetDefault("port", -1)
 	pflag.IntP("secureport", "t", -1, "HTTPS listen port")
@@ -54,6 +56,7 @@ func SetConfigDefaults() {
 }
 
 func getConfig() error {
+	viper.BindPFlag("localBindIpAddr", pflag.Lookup("localbindipaddr"))
 	viper.BindPFlag("port", pflag.Lookup("port"))
 	viper.BindPFlag("securePort", pflag.Lookup("secureport"))
 	viper.BindPFlag("mgmtPort", pflag.Lookup("mgmtport"))

--- a/snapshotserver/main.go
+++ b/snapshotserver/main.go
@@ -18,6 +18,7 @@ package snapshotserver
 import (
 	"database/sql"
 	"errors"
+	"net"
 	"net/http"
 	"time"
 
@@ -63,6 +64,7 @@ func Run() (*goscaffold.HTTPScaffold, error) {
 	}
 
 	// Fetch config values from Viper
+	localBindIpAddr := viper.GetString("localBindIpAddr")
 	port := viper.GetInt("port")
 	securePort := viper.GetInt("securePort")
 	mgmtPort := viper.GetInt("mgmtPort")
@@ -120,6 +122,10 @@ func Run() (*goscaffold.HTTPScaffold, error) {
 		})
 
 	scaf := goscaffold.CreateHTTPScaffold()
+	ip := net.ParseIP(localBindIpAddr)
+	if ip != nil {
+		scaf.SetlocalBindIPAddressV4(ip)
+	}
 	scaf.SetInsecurePort(port)
 	scaf.SetSecurePort(securePort)
 	if mgmtPort >= 0 {

--- a/snapshotserver/snapshot_info_test.go
+++ b/snapshotserver/snapshot_info_test.go
@@ -51,8 +51,8 @@ var (
 func TestSnapshot(t *testing.T) {
 	dbURL = os.Getenv("TEST_PG_URL")
 	if dbURL == "" {
-		t.Logf("Cannot run snapshot tests because TEST_PG_URL not set\n")
-		t.Logf("  Example: postgres://user:password@host:port/database\n")
+		t.Log("Cannot run snapshot tests because TEST_PG_URL not set\n")
+		t.Log("  Example: postgres://user:password@host:port/database\n")
 		t.Fatal("Aborting snapshot tests because they depend on Postgres.")
 	} else {
 		RegisterFailHandler(Fail)
@@ -85,6 +85,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).Should(Succeed())
 
 	SetConfigDefaults()
+	viper.Set("localBindIpAddr", "127.0.0.1")
 	viper.Set("port", 0)
 	viper.Set("pgURL", dbURL)
 	viper.Set("debug", debugTests)
@@ -103,7 +104,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	fmt.Fprintf(GinkgoWriter, "Stopping listener\n")
+	fmt.Fprint(GinkgoWriter, "Stopping listener\n")
 	testListener.Shutdown(nil)
 
 	for _, table := range allTables {


### PR DESCRIPTION
Specify loopback IP for snapshot tests to prevent OS X firewall dialog
popup about allowing incoming connections while developing on laptop

Also fix IntelliJ go inspection warnings