### PR TITLE
add sqlite type for each column to _transicator_tables

### DIFF
--- a/snapshotserver/snapshot.go
+++ b/snapshotserver/snapshot.go
@@ -466,7 +466,7 @@ func DownloadSnapshot(
 	case sqliteDataType:
 		err := WriteSqliteSnapshot(scopes, db, w, r)
 		if err != nil {
-			log.Errorf("GetTenantSnapshotData error: %v", err)
+			log.Errorf("Sqlite snapshot error: %v", err)
 		}
 		return
 	case protoType:


### PR DESCRIPTION
We should propagate the sqlite type that transicator decided to convert the original PG type into, since that info is readily available during db construction time, and will save consumers the burden of inspecting the db for this metadata.  This info is necessary to construct the proper dml for changes.