### PR TITLE
Xapid 937

### DIFF
--- a/snapshotserver/snapshot_api_test.go
+++ b/snapshotserver/snapshot_api_test.go
@@ -187,9 +187,9 @@ var _ = Describe("Snapshot API Tests", func() {
 		Expect(err).Should(Succeed())
 		_, err = io.Copy(outFile, resp.Body)
 		outFile.Close()
-		err, cksum := getSHA256Checksum(dbFileName)
+		err, cksum := generateEtag(dbFileName)
 		Expect(err).Should(Succeed())
-		Expect(resp.Header.Get("SHA256Sum")).To(Equal(cksum))
+		Expect(resp.Header.Get("ETag")).To(Equal(cksum))
 		Expect(err).Should(Succeed())
 
 		sdb, err := sql.Open("sqlite3", dbFileName)
@@ -271,9 +271,9 @@ var _ = Describe("Snapshot API Tests", func() {
 		outFile.Close()
 		Expect(err).Should(Succeed())
 
-		err, cksum := getSHA256Checksum(dbFileName)
+		err, cksum := generateEtag(dbFileName)
 		Expect(err).Should(Succeed())
-		Expect(resp.Header.Get("SHA256Sum")).To(Equal(cksum))
+		Expect(resp.Header.Get("ETag")).To(Equal(cksum))
 
 		sdb, err := sql.Open("sqlite3", dbFileName)
 		Expect(err).Should(Succeed())
@@ -487,9 +487,9 @@ func getSqliteSnapshot(dbDir, scope string) (*sql.DB, string) {
 	_, err = io.Copy(outFile, resp.Body)
 	outFile.Close()
 	Expect(err).Should(Succeed())
-	err, cksum := getSHA256Checksum(dbFileName)
+	err, cksum := generateEtag(dbFileName)
 	Expect(err).Should(Succeed())
-	Expect(resp.Header.Get("SHA256Sum")).To(Equal(cksum))
+	Expect(resp.Header.Get("ETag")).To(Equal(cksum))
 	Expect(err).Should(Succeed())
 
 	sdb, err := sql.Open("sqlite3", dbFileName)

--- a/snapshotserver/sqlite.go
+++ b/snapshotserver/sqlite.go
@@ -368,11 +368,7 @@ func streamFile(srcFile string, w http.ResponseWriter) error {
 		return err
 	}
 	defer inFile.Close()
-
 	_, err = io.Copy(w, inFile)
-	if err != nil {
-		return err
-	}
 
 	return err
 }

--- a/snapshotserver/sqlite.go
+++ b/snapshotserver/sqlite.go
@@ -369,6 +369,5 @@ func streamFile(srcFile string, w http.ResponseWriter) error {
 	}
 	defer inFile.Close()
 	_, err = io.Copy(w, inFile)
-
 	return err
 }

--- a/test/combined_test_script.sh
+++ b/test/combined_test_script.sh
@@ -31,8 +31,11 @@ TEST_COVERAGE_FILENAME=${TEST_COVERAGE_FILENAME:-coverage.txt}
 TEST_COVERAGE_OUTPUT=${DIR}/../test-reports/${TEST_COVERAGE_FILENAME}
 TEST_MODULES="./test"
 if [[ "${TEST_COVERAGE}" == "true" ]]; then
+  if [ ! -f "${TEST_COVERAGE_OUTPUT}" ]; then
+    echo "mode: count" | tee ${TEST_COVERAGE_OUTPUT}
+  fi
   for package in ${TEST_MODULES}; do
-    go test -coverprofile=profile.out $package
+    go test -coverprofile=profile.out -covermode=count $package
     result=$?
     if [ $result -ne 0 ]; then
       error=$result

--- a/test/container_test_script.sh
+++ b/test/container_test_script.sh
@@ -37,8 +37,11 @@ TEST_COVERAGE_OUTPUT=${DIR}/../test-reports/${TEST_COVERAGE_FILENAME}
 TEST_MODULES="./common ./storage ./pgclient \
               ./replication ./snapshotserver ./changeserver"
 if [[ "${TEST_COVERAGE}" == "true" ]]; then
+  if [ ! -f "${TEST_COVERAGE_OUTPUT}" ]; then
+    echo "mode: count" | tee ${TEST_COVERAGE_OUTPUT}
+  fi
   for package in ${TEST_MODULES}; do
-    go test -coverprofile=profile.out $package
+    go test -coverprofile=profile.out -covermode=count $package
     result=$?
     if [ $result -ne 0 ]; then
       error=$result

--- a/test/dockertest.sh
+++ b/test/dockertest.sh
@@ -23,6 +23,8 @@ then
   read -s TEST_PG_PW
 fi
 
+finalExitCode=0
+
 rm -rf ${working_dir}/docker-test-reports
 mkdir ${working_dir}/docker-test-reports
 
@@ -55,6 +57,10 @@ docker run -i \
   -e TEST_COVERAGE_FILENAME=coverage_container_test.txt \
   ${testName} \
   /go/src/github.com/apigee-labs/transicator/test/container_test_script.sh
+if [ $? -ne 0 ]
+then
+  finalExitCode=$?
+fi
 
 # Copy JUnit test files and rm container
 docker cp ${testName}:/go/src/github.com/apigee-labs/transicator/test-reports/. ./docker-test-reports
@@ -103,6 +109,10 @@ docker run -i \
   -e TEST_COVERAGE_FILENAME=coverage_combined_test.txt \
   ${testName} \
   /go/src/github.com/apigee-labs/transicator/test/combined_test_script.sh
+if [ $? -ne 0 ]
+then
+  finalExitCode=$?
+fi
 
 # No test-reports to get. Combined tests are black box and won't show coverage
 
@@ -139,3 +149,5 @@ then
   fi
 fi
 ${RMCMD} ${testName} ${ssName} ${csName} ${dbName}
+
+exit ${finalExitCode}


### PR DESCRIPTION
Not using ETag, as currently snapshot server has no means to store this, and use it in the future for comparison purpose. So currently calling the header as "SHA256Sum".
Also, could not avoid dual reads (using teeReader), as the response header cannot be accessed once the io.Copy on the response is performed.