### PR TITLE
Incident:XAPID-951

### DIFF
--- a/snapshotserver/sqlite.go
+++ b/snapshotserver/sqlite.go
@@ -253,17 +253,16 @@ func copyData(pgTx *sql.Tx, tdb *sql.DB, scopes []string, pgTable *pgTable) erro
 	sql = makeInsertSQL(pgTable, colNames)
 	log.Debugf("Sqlite insert: %s", sql)
 
-	tx, err := tdb.Begin()
-	if err != nil {
-		return err
-	}
-
 	stmt, err := tdb.Prepare(sql)
 	if err != nil {
 		return err
 	}
 	defer stmt.Close()
 
+	tx, err := tdb.Begin()
+	if err != nil {
+		return err
+	}
 	for pgRows.Next() {
 		cols := make([]interface{}, len(colNames))
 		for i := range cols {


### PR DESCRIPTION
The sqlite table level commits will be done as txn. Otherwise, every row inserts results in a disk i/o.
With this fix, there is between a 6 - 10 times performs improvement.
Ensured that the test cases work without regression.