### PR TITLE
Release 170815 edge x eap xapid1087

### DIFF
--- a/changeserver/config.go
+++ b/changeserver/config.go
@@ -73,8 +73,8 @@ func getConfig() error {
 	// Load config values from file
 	if viper.GetString("configFile") != "" {
 		viper.AddConfigPath(viper.GetString("configFile"))
-		err := viper.ReadInConfig()                           // Find and read the config file
-		if err != nil {                                       // Handle errors reading the config file
+		err := viper.ReadInConfig() // Find and read the config file
+		if err != nil {             // Handle errors reading the config file
 			return err
 		}
 	}

--- a/changeserver/config.go
+++ b/changeserver/config.go
@@ -16,9 +16,6 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
@@ -49,7 +46,7 @@ func setConfigDefaults() {
 	viper.SetDefault("prefix", "")
 	viper.SetDefault("selectorColumn", defaultSelectorColumn)
 
-	pflag.BoolP("config", "C", false, fmt.Sprintf("Use a config file named '%s' located in either /etc/%s/, ~/.%s or ./)", appName, packageName, packageName))
+	pflag.StringP("config", "C", "", "specify the config directory (ONLY) for changeserver.properties")
 	pflag.BoolP("debug", "D", false, "Turn on debugging")
 	viper.SetDefault("debug", false)
 }
@@ -72,14 +69,12 @@ func getConfig() error {
 	viper.BindPFlag("debug", pflag.Lookup("debug"))
 	viper.BindPFlag("selectorColumn", pflag.Lookup("selectorcolumn"))
 
+	viper.SetConfigName(appName)
 	// Load config values from file
-	if viper.GetBool("configFile") {
-		viper.SetConfigName(appName)                                               // name of config file (without extension)
-		viper.AddConfigPath(fmt.Sprintf("/etc/%s/", packageName))                  // path to look for the config file in
-		viper.AddConfigPath(fmt.Sprintf("%s/.%s", os.Getenv("HOME"), packageName)) // loof for config in the users home directory
-		viper.AddConfigPath(".")                                                   // look for config in the working directory
-		err := viper.ReadInConfig()                                                // Find and read the config file
-		if err != nil {                                                            // Handle errors reading the config file
+	if viper.GetString("configFile") != "" {
+		viper.AddConfigPath(viper.GetString("configFile"))
+		err := viper.ReadInConfig()                           // Find and read the config file
+		if err != nil {                                       // Handle errors reading the config file
 			return err
 		}
 	}

--- a/snapshotserver/config.go
+++ b/snapshotserver/config.go
@@ -47,13 +47,13 @@ func SetConfigDefaults() {
 	pflag.StringP("tempdir", "T", "", "Set temporary directory for snapshot files")
 	viper.SetDefault("tempdir", defaultTempDir)
 
-	pflag.IntP("connmaxlife", "x", 5, "Sets the maximum amount of time (Minutes) a connection may be reused")
-	viper.SetDefault("connmaxlife", 5)
+	pflag.IntP("connmaxlife", "", connmaxlifeInMinutes, "Sets the maximum amount of time (Minutes) a connection may be reused")
+	viper.SetDefault("connmaxlife", connmaxlifeInMinutes)
 
-	pflag.IntP("maxidleconns", "y", -1, "Sets the maximum number of connections in the idle connection pool")
+	pflag.IntP("maxidleconns", "", -1, "Sets the maximum number of connections in the idle connection pool")
 	viper.SetDefault("maxidleconns", -1)
 
-	pflag.IntP("maxopenconns", "z", -1, "Sets the maximum number of open connections to the database")
+	pflag.IntP("maxopenconns", "", -1, "Sets the maximum number of open connections to the database")
 	viper.SetDefault("maxopenconns", -1)
 
 	pflag.StringP("config", "C", "", "specify the config directory (ONLY) for snapshotserver.properties")
@@ -85,12 +85,11 @@ func getConfig() error {
 	// Load config values from file
 	if viper.GetString("configFile") != "" {
 		viper.AddConfigPath(viper.GetString("configFile"))
-		err := viper.ReadInConfig()                                                // Find and read the config file
-		if err != nil {                                                            // Handle errors reading the config file
+		err := viper.ReadInConfig() // Find and read the config file
+		if err != nil {             // Handle errors reading the config file
 			return err
 		}
 	}
-
 
 	// Load any config values from Environment variables who's name is prefixed TSS_ (Transicator Snaphot Server)
 	viper.SetEnvPrefix("tss") // will be uppercased automatically
@@ -99,4 +98,3 @@ func getConfig() error {
 	return nil
 
 }
-

--- a/snapshotserver/main.go
+++ b/snapshotserver/main.go
@@ -78,6 +78,10 @@ func Run() (*goscaffold.HTTPScaffold, error) {
 	selectorColumn = viper.GetString("selectorColumn")
 	tempSnapshotDir = viper.GetString("tempdir")
 
+	cml := viper.GetInt("connMaxLife")
+	mic := viper.GetInt("maxIdleConns")
+	moc := viper.GetInt("maxOpenConns")
+
 	if pgURL == "" {
 		return nil, ErrUsage
 	}
@@ -105,6 +109,26 @@ func Run() (*goscaffold.HTTPScaffold, error) {
 	pgdriver.SetIsolationLevel("repeatable read")
 	pgdriver.SetExtendedColumnNames(true)
 	pgdriver.SetReadTimeout(defaultPGTimeout)
+
+
+	log.Infof("Set SetConnMaxLifetime to %d minutes", cml)
+	mainDB.SetConnMaxLifetime(time.Duration(cml) * time.Minute)
+
+	if mic >= 0 {
+		log.Infof("Set SetMaxIdleConns to %d", mic)
+		mainDB.SetMaxIdleConns(mic)
+	}
+
+	if moc >= 0 {
+		log.Infof("Set SetMaxOpenConns to %d", moc)
+		mainDB.SetMaxOpenConns(moc)
+	}
+
+	// In the future, the return param to schedule() can be used to stop stats collection
+	if debug {
+		schedule(getStatsInfo, time.Second * 5)
+	}
+
 	router := httprouter.New()
 
 	router.GET("/scopes/:apidclusterId",
@@ -176,4 +200,24 @@ func checkHealth(db *sql.DB) (goscaffold.HealthStatus, error) {
 	// status here that would cause a restart. We will be able to reach PG
 	// again when it's ready.
 	return goscaffold.NotReady, err
+}
+
+
+func schedule(cback func(), delay time.Duration) chan bool {
+	stop := make(chan bool)
+	go func() {
+		for {
+			select {
+			case <-time.After(delay):
+				cback()
+			case <-stop:
+				return
+			}
+		}
+	}()
+	return stop
+}
+
+func getStatsInfo() {
+	log.Debugf("Current open DB connections %d", mainDB.Stats().OpenConnections)
 }

--- a/snapshotserver/snapshot_info_test.go
+++ b/snapshotserver/snapshot_info_test.go
@@ -89,6 +89,7 @@ var _ = BeforeSuite(func() {
 	viper.Set("port", 0)
 	viper.Set("pgURL", dbURL)
 	viper.Set("debug", debugTests)
+	viper.Set("connmaxlife", 2)
 
 	testListener, err = Run()
 	Expect(err).Should(Succeed())


### PR DESCRIPTION
There are two set of changes:-
1) Make "-C" option provide the directory path to snapshotserver.properties. Earlier it was a boolean and was looking in to home directory, /etc/apigee etc.
The above is for both Snapshot server and Change server.

2) In Snapshot server, added options to Set DB params.
Verified on production that we no longer see DB connection terminated with "broken pipe" anymore.
 
